### PR TITLE
Erase the previous content in the buffer by posframe-delete

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -256,7 +256,7 @@ This variable is useful for `ivy-posframe-read-action' .")
 (defun ivy-posframe-cleanup ()
   "Cleanup ivy's posframe."
   (when (posframe-workable-p)
-    (posframe-hide ivy-posframe-buffer)
+    (posframe-delete ivy-posframe-buffer)
     (setq ivy-posframe--display-p nil)))
 
 (defun ivy-posframe-dispatching-done ()


### PR DESCRIPTION
Thx for creating such a nice package!  
I found that `ivy-posframe-buffer` holds the previous contents and looks as if it were blinking like below.

![ivy-posframe](https://user-images.githubusercontent.com/8979468/55094219-4ec31f80-50f9-11e9-981c-95091362a6cf.gif)

---

To avoid this phenomenon, I thought, we should use `posframe-delete` instead of `posframe-hide`.

![ivy-posframe2](https://user-images.githubusercontent.com/8979468/55095354-54ba0000-50fb-11e9-939e-93016420e41e.gif)
