### PR TITLE
Get correct prompt for recursive minibuffers

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -206,7 +206,7 @@ This variable is useful for `ivy-posframe-read-action' .")
        ivy-posframe-buffer
        :font ivy-posframe-font
        :string
-       (with-current-buffer (get-buffer-create " *Minibuf-1*")
+       (with-current-buffer (window-buffer (active-minibuffer-window))
          (let ((point (point))
                (string (if ivy-posframe--ignore-prompt
                            str


### PR DESCRIPTION
This closes #28. There was a fix for this upstream in abo-abo/swiper#1995. The only thing that ivy-posframe needs to do is get the correct prompt. So we get the active minibuffer instead of trying to guess the name.