### PR TITLE
Erase the contents before closing ivy-posframe-buffer

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -168,6 +168,12 @@ When 0, no border is showed."
   :group 'ivy-posframe
   :type 'string)
 
+(defcustom ivy-posframe-delete-content-after-hide nil
+  "Whether ivy-posframe should delete the buffer content 
+after hide the posframe."
+  :group 'ivy-posframe
+  :type 'boolean)
+
 (defface ivy-posframe
   '((t (:inherit default)))
   "Face used by the ivy-posframe."
@@ -253,10 +259,20 @@ This variable is useful for `ivy-posframe-read-action' .")
 (defun ivy-posframe-display-at-point (str)
   (ivy-posframe--display str #'posframe-poshandler-point-bottom-left-corner))
 
+(defun ivy-posframe--delete-content (posframe-buffer)
+  (dolist (frame (frame-list))
+    (let ((buffer-info (frame-parameter frame 'posframe-buffer)))
+      (when (or (equal posframe-buffer (car buffer-info))
+                (equal posframe-buffer (cdr buffer-info)))
+        (with-current-buffer posframe-buffer (erase-buffer))
+        (redraw-frame frame)))))
+
 (defun ivy-posframe-cleanup ()
   "Cleanup ivy's posframe."
   (when (posframe-workable-p)
     (posframe-hide ivy-posframe-buffer)
+    (if ivy-posframe-delete-content-after-hide
+        (ivy-posframe--delete-content ivy-posframe-buffer))
     (setq ivy-posframe--display-p nil)))
 
 (defun ivy-posframe-dispatching-done ()


### PR DESCRIPTION
As mentioned before in https://github.com/tumashu/ivy-posframe/pull/27, need to delete the contents in `ivy-posframe-buffer` when closing it.  
In this PR, simply using `erase-buffer` to delete the contents instead of `posframe-delete`.

---
Checked Environment:
+ Emacs26.1 on MacOS(Mojave)

![ivy-posframe](https://user-images.githubusercontent.com/8979468/55567832-763d6c00-5739-11e9-9c91-4197324f79f6.gif)
