### PR TITLE
Remove top-level ivy-posframe setup function executing

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -445,8 +445,6 @@ selection, non-nil otherwise."
          (push `(,func :cleanup ivy-posframe-cleanup)
                ivy-display-functions-props)))))
 
-(ivy-posframe-setup)
-
 (provide 'ivy-posframe)
 
 ;; Local Variables:


### PR DESCRIPTION
Hi!

I found elisp package issue.
Please let me know if there is a special reason.

---
Many users want that the behavior of Emacs does not change just by
`require`. (Unless package have different files for configuration.)

Currently, if you require a package, ivy-posframe-setup will be executed
unconditionally, which may violate the user's intention.

Users need to call `ivy-posframe-enable` separately if they want to use
`ivy-posframe` (because it changes the behavior of `ivy`), and it is already
designed to execute `ivy-posframe-setup` from this function.