### PR TITLE
fixed window size and number of candidates mismatch

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -410,8 +410,12 @@ selection, non-nil otherwise."
   "Advice function of `ivy--minibuffer-setup'."
   (let ((ivy-fixed-height-minibuffer nil))
     (funcall orig-func))
+
+  ;; change ivy-height as let variable defined in ivy.el:L1936 at c47a7dc
   (when ivy-posframe-min-height
     (setq ivy-height (max ivy-height ivy-posframe-min-height)))
+
+  ;; additional minibuffer configrations
   (when (and ivy-posframe-hide-minibuffer
              ;; only hide minibuffer's info when posframe is showed.
              ivy-posframe--display-p)

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -410,6 +410,8 @@ selection, non-nil otherwise."
   "Advice function of `ivy--minibuffer-setup'."
   (let ((ivy-fixed-height-minibuffer nil))
     (funcall orig-func))
+  (when ivy-posframe-min-height
+    (setq ivy-height (max ivy-height ivy-posframe-min-height)))
   (when (and ivy-posframe-hide-minibuffer
              ;; only hide minibuffer's info when posframe is showed.
              ivy-posframe--display-p)


### PR DESCRIPTION
Hi @tumashu!

I wanted to change the height when `ivy-posframe` is enabled but use default value on normal ivy.
We probably want to set more widths than usual when `ivy-posframe` is on.

I set it this way and expect that the height of `ivy` would change, but in reality only the height of `posframe` would change and there would be more blank areas.

In practice, this is the result of two packages fulfilling their respective responsibilities.
`ivy` created a candidate for `ivy-height`, and `ivy-posframe` displayed the string that ivy passed.

This is a policy issue. Do you want to fix this?
At first glance, the source looks like it's changing globally, but as I mentioned in the comment, it's actually changing the `let` variables [here](https://github.com/abo-abo/swiper/blob/c47a7dcd14e9090f27eba5ac0dd7f55bb9cc7770/ivy.el#L1936), so there's no global impact.

If you do not change this behavior, it is recommended that we annotate the README.

![Capture 2019-04-27 9 50 39](https://user-images.githubusercontent.com/4703128/56844251-40c71100-68e8-11e9-8f22-880d51bcdc5f.png)

## init.el
```
(leaf ivy
  :ensure t
  :config
  (leaf *ivy-ui-requirements
    :config
    (leaf swiper :ensure t)
    (leaf counsel :ensure t))

  (leaf *other-ivy-packages
    :config
    (leaf ivy-posframe
      :doc "Using posframe to show Ivy"
      :when window-system
      :ensure t
      :custom ((ivy-display-function    . #'ivy-posframe-display-at-frame-center)
               (ivy-posframe-min-height . 40)
               (ivy-posframe-parameters . '((left-fringe . 10))))
      :config
      (let ((inhibit-message t))
        (ivy-posframe-enable))))

  (leaf *ivy-settings
    :config
    (ivy-mode 1)
    (counsel-mode 1)))
```