### PR TITLE
requires ivy v0.11.0

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -8,7 +8,7 @@
 ;; URL: https://github.com/tumashu/ivy-posframe
 ;; Version: 0.1.0
 ;; Keywords: abbrev, convenience, matching, ivy
-;; Package-Requires: ((emacs "26.0")(posframe "0.1.0")(ivy "0.10.0"))
+;; Package-Requires: ((emacs "26.0")(posframe "0.1.0")(ivy "0.11.0"))
 
 ;; This file is part of GNU Emacs.
 


### PR DESCRIPTION
On #38, mismatched dependencies were reported so I fix it.

ivy-posframe requires `ivy-display-functions-props` added by abo-abo/swiper@455ec84, specifying v0.11.0 is the minimum required.