### PR TITLE
Fix "ivy-posframe copies prompt text as kill" #41

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -268,7 +268,9 @@ This variable is useful for `ivy-posframe-read-action' .")
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
           (goto-char (point-min))
-          (kill-line 1)
+          (delete-region
+           (point)
+           (save-excursion (move-end-of-line 1) (point)))
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -268,9 +268,7 @@ This variable is useful for `ivy-posframe-read-action' .")
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
           (goto-char (point-min))
-          (delete-region
-           (point)
-           (save-excursion (move-end-of-line 1) (point)))
+          (delete-region (point) (save-excursion (line-move 1 'noerror) (point)))
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 


### PR DESCRIPTION
This issue seems due to `(kill-line 1)` part from the latest merge.
I modified this line so that it does not save the deleted prompt to `kill-ring`.
Thanks!