### PR TITLE
Ivy-posframe now minor-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
 Note: this file is auto converted from ivy-posframe.el by [el2org](https://github.com/tumashu/el2org), please do not edit it by hand!!!
 
 
-# &#30446;&#24405;
+# Table of Contents
 
-1.  [ivy-posframe README](#orgf13cc66)
-    1.  [What is ivy-posframe](#orgbd4ba62)
-    2.  [Display functions](#orge8456a3)
-    3.  [How to enable ivy-posframe](#orge72596b)
-        1.  [Global mode](#org359004f)
-        2.  [Per-command mode.](#orgdfd4dbf)
-        3.  [Fallback mode](#org589575f)
-    4.  [Tips](#orgd8d788b)
-        1.  [How to show fringe to ivy-posframe](#org44b1a57)
-        2.  [How to custom your ivy-posframe style](#org2e4b09d)
+1.  [ivy-posframe README](#orgd3c904b)
+    1.  [What is ivy-posframe](#org0585c98)
+    2.  [Display functions](#org33d88e8)
+    3.  [How to enable ivy-posframe](#org1951a71)
+        1.  [Global mode](#orga4b2102)
+        2.  [Per-command mode.](#org5502e77)
+    4.  [Tips](#orgaaa4442)
+        1.  [How to show fringe to ivy-posframe](#org84cabb8)
+        2.  [How to custom your ivy-posframe style](#orgc5ae827)
 
 
-<a id="orgf13cc66"></a>
+<a id="orgd3c904b"></a>
 
 # ivy-posframe README
 
 
-<a id="orgbd4ba62"></a>
+<a id="org0585c98"></a>
 
 ## What is ivy-posframe
 
@@ -31,7 +30,7 @@ NOTE: ivy-posframe requires Emacs 26 and do not support mouse
 click.
 
 
-<a id="orge8456a3"></a>
+<a id="org33d88e8"></a>
 
 ## Display functions
 
@@ -47,35 +46,56 @@ click.
     ![img](./snapshots/ivy-posframe-display-at-point.png)
 
 
-<a id="orge72596b"></a>
+<a id="org1951a71"></a>
 
 ## How to enable ivy-posframe
 
 
-<a id="org359004f"></a>
+<a id="orga4b2102"></a>
 
 ### Global mode
 
     (require 'ivy-posframe)
-    (setq ivy-display-function #'ivy-posframe-display)
-    ;; (setq ivy-display-function #'ivy-posframe-display-at-frame-center)
-    ;; (setq ivy-display-function #'ivy-posframe-display-at-window-center)
-    ;; (setq ivy-display-function #'ivy-posframe-display-at-frame-bottom-left)
-    ;; (setq ivy-display-function #'ivy-posframe-display-at-window-bottom-left)
-    ;; (setq ivy-display-function #'ivy-posframe-display-at-point)
-    (ivy-posframe-enable)
+    (setq ivy-posframe-configure-alist
+          '((ivy-display-functions-alist . ((t . ivy-posframe-display)))))
+    ;; (setq ivy-posframe-configure-alist
+    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-center)))))
+    ;; (setq ivy-posframe-configure-alist
+    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-center)))))
+    ;; (setq ivy-posframe-configure-alist
+    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-bottom-left)))))
+    ;; (setq ivy-posframe-configure-alist
+    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-bottom-left)))))
+    ;; (setq ivy-posframe-configure-alist
+    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-point)))))
+    (ivy-posframe-mode t)
 
 
-<a id="orgdfd4dbf"></a>
+<a id="org5502e77"></a>
 
 ### Per-command mode.
 
     (require 'ivy-posframe)
     ;; Different command can use different display function.
-    (push '(counsel-M-x . ivy-posframe-display-at-window-bottom-left) ivy-display-functions-alist)
-    (push '(complete-symbol . ivy-posframe-display-at-point) ivy-display-functions-alist)
-    (push '(swiper . ivy-posframe-display-at-point) ivy-display-functions-alist)
-    (ivy-posframe-enable)
+    (setq ivy-posframe-configure-alist
+          '((ivy-display-functions-alist . ((swiper          . ivy-posframe-display-at-point)
+                                            (complete-symbol . ivy-posframe-display-at-point)
+                                            (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+                                            (t               . ivy-posframe-display)))))
+    (ivy-posframe-mode t)
+
+You can use ivy original display function on specify function.
+You may want to use the original display function because display
+of Swiper at point hides the contents of the buffer.
+
+    (require 'ivy-posframe)
+    ;; Different command can use different display function.
+    (setq ivy-posframe-configure-alist
+          '((ivy-display-functions-alist . ((swiper          . nil)
+                                            (complete-symbol . ivy-posframe-display-at-point)
+                                            (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+                                            (t               . ivy-posframe-display)))))
+    (ivy-posframe-mode t)
 
 NOTE: Using swiper as example: swiper's display function **only**
 take effect when you call swiper command with global keybinding, if
@@ -88,21 +108,12 @@ by ivy to find display function in \`ivy-display-functions-alist',
 "C-h v this-command" is a good idea.
 
 
-<a id="org589575f"></a>
-
-### Fallback mode
-
-    (require 'ivy-posframe)
-    (push '(t . ivy-posframe-display) ivy-display-functions-alist)
-    (ivy-posframe-enable)
-
-
-<a id="orgd8d788b"></a>
+<a id="orgaaa4442"></a>
 
 ## Tips
 
 
-<a id="org44b1a57"></a>
+<a id="org84cabb8"></a>
 
 ### How to show fringe to ivy-posframe
 
@@ -114,7 +125,7 @@ By the way, User can set **any** parameters of ivy-posframe with
 the help of \`ivy-posframe-parameters'.
 
 
-<a id="org2e4b09d"></a>
+<a id="orgc5ae827"></a>
 
 ### How to custom your ivy-posframe style
 
@@ -122,5 +133,6 @@ The simplest way is:
 
     (defun ivy-posframe-display-at-XXX (str)
       (ivy-posframe--display str #'your-own-poshandler-function))
-    (ivy-posframe-enable) ; This line is needed.
+    (push 'ivy-posframe-display-at-XXX ivy-posframe-display-function-list) ; This line is needed.
+    (ivy-posframe-mode t) ; This line is needed.
 

--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@ Note: this file is auto converted from ivy-posframe.el by [el2org](https://githu
 
 # Table of Contents
 
-1.  [ivy-posframe README](#orgd3c904b)
-    1.  [What is ivy-posframe](#org0585c98)
-    2.  [Display functions](#org33d88e8)
-    3.  [How to enable ivy-posframe](#org1951a71)
-        1.  [Global mode](#orga4b2102)
-        2.  [Per-command mode.](#org5502e77)
-    4.  [Tips](#orgaaa4442)
-        1.  [How to show fringe to ivy-posframe](#org84cabb8)
-        2.  [How to custom your ivy-posframe style](#orgc5ae827)
+1.  [ivy-posframe README](#orgb29527d)
+    1.  [What is ivy-posframe](#org73ec970)
+    2.  [Display functions](#org7dc9307)
+    3.  [How to enable ivy-posframe](#org491e830)
+        1.  [Global mode](#org38e37cf)
+        2.  [Per-command mode.](#org89e4db4)
+    4.  [Tips](#org2af7073)
+        1.  [How to show fringe to ivy-posframe](#orgc0851d4)
+        2.  [How to custom your ivy-posframe style](#orgdab58bc)
 
 
-<a id="orgd3c904b"></a>
+<a id="orgb29527d"></a>
 
 # ivy-posframe README
 
 
-<a id="org0585c98"></a>
+<a id="org73ec970"></a>
 
 ## What is ivy-posframe
 
@@ -30,7 +30,7 @@ NOTE: ivy-posframe requires Emacs 26 and do not support mouse
 click.
 
 
-<a id="org33d88e8"></a>
+<a id="org7dc9307"></a>
 
 ## Display functions
 
@@ -46,42 +46,36 @@ click.
     ![img](./snapshots/ivy-posframe-display-at-point.png)
 
 
-<a id="org1951a71"></a>
+<a id="org491e830"></a>
 
 ## How to enable ivy-posframe
 
 
-<a id="orga4b2102"></a>
+<a id="org38e37cf"></a>
 
 ### Global mode
 
     (require 'ivy-posframe)
-    (setq ivy-posframe-configure-alist
-          '((ivy-display-functions-alist . ((t . ivy-posframe-display)))))
-    ;; (setq ivy-posframe-configure-alist
-    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-center)))))
-    ;; (setq ivy-posframe-configure-alist
-    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-center)))))
-    ;; (setq ivy-posframe-configure-alist
-    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-bottom-left)))))
-    ;; (setq ivy-posframe-configure-alist
-    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-bottom-left)))))
-    ;; (setq ivy-posframe-configure-alist
-    ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-point)))))
+    ;; display at `ivy-posframe-style'
+    (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display)))
+    ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-frame-center)))
+    ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-window-center)))
+    ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-frame-bottom-left)))
+    ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-window-bottom-left)))
     (ivy-posframe-mode t)
 
 
-<a id="org5502e77"></a>
+<a id="org89e4db4"></a>
 
 ### Per-command mode.
 
     (require 'ivy-posframe)
     ;; Different command can use different display function.
-    (setq ivy-posframe-configure-alist
-          '((ivy-display-functions-alist . ((swiper          . ivy-posframe-display-at-point)
-                                            (complete-symbol . ivy-posframe-display-at-point)
-                                            (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
-                                            (t               . ivy-posframe-display)))))
+    (setq ivy-posframe-display-functions-alist
+          '((swiper          . ivy-posframe-display-at-point)
+            (complete-symbol . ivy-posframe-display-at-point)
+            (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+            (t               . ivy-posframe-display)))
     (ivy-posframe-mode t)
 
 You can use ivy original display function on specify function.
@@ -90,11 +84,30 @@ of Swiper at point hides the contents of the buffer.
 
     (require 'ivy-posframe)
     ;; Different command can use different display function.
-    (setq ivy-posframe-configure-alist
-          '((ivy-display-functions-alist . ((swiper          . nil)
-                                            (complete-symbol . ivy-posframe-display-at-point)
-                                            (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
-                                            (t               . ivy-posframe-display)))))
+    (setq ivy-posframe-display-functions-alist
+          '((swiper          . nil)
+            (complete-symbol . ivy-posframe-display-at-point)
+            (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+            (t               . ivy-posframe-display)))
+    (ivy-posframe-mode t)
+
+You may want to change the height of ivy by a function only while
+using posframe. This is possible with the code below.
+
+The following example displays swiper on 20 lines by default for ivy,
+and displays other functions in posframe at the location specified on
+40 lines.
+
+    (require 'ivy-posframe)
+    ;; Different command can use different display function.
+    (setq ivy-posframe-height-alist '((swiper . 20)
+                                      (t      . 40)))
+    
+    (setq ivy-posframe-display-functions-alist
+          '((swiper          . nil)
+            (complete-symbol . ivy-posframe-display-at-point)
+            (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+            (t               . ivy-posframe-display)))
     (ivy-posframe-mode t)
 
 NOTE: Using swiper as example: swiper's display function **only**
@@ -108,12 +121,12 @@ by ivy to find display function in \`ivy-display-functions-alist',
 "C-h v this-command" is a good idea.
 
 
-<a id="orgaaa4442"></a>
+<a id="org2af7073"></a>
 
 ## Tips
 
 
-<a id="org84cabb8"></a>
+<a id="orgc0851d4"></a>
 
 ### How to show fringe to ivy-posframe
 
@@ -125,7 +138,7 @@ By the way, User can set **any** parameters of ivy-posframe with
 the help of \`ivy-posframe-parameters'.
 
 
-<a id="orgc5ae827"></a>
+<a id="orgdab58bc"></a>
 
 ### How to custom your ivy-posframe style
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -54,21 +54,43 @@
 ;; *** Global mode
 ;; #+BEGIN_EXAMPLE
 ;; (require 'ivy-posframe)
-;; (setq ivy-display-function #'ivy-posframe-display)
-;; ;; (setq ivy-display-function #'ivy-posframe-display-at-frame-center)
-;; ;; (setq ivy-display-function #'ivy-posframe-display-at-window-center)
-;; ;; (setq ivy-display-function #'ivy-posframe-display-at-frame-bottom-left)
-;; ;; (setq ivy-display-function #'ivy-posframe-display-at-window-bottom-left)
-;; ;; (setq ivy-display-function #'ivy-posframe-display-at-point)
+;; (setq ivy-posframe-configure-alist
+;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display)))))
+;; ;; (setq ivy-posframe-configure-alist
+;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-center)))))
+;; ;; (setq ivy-posframe-configure-alist
+;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-center)))))
+;; ;; (setq ivy-posframe-configure-alist
+;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-bottom-left)))))
+;; ;; (setq ivy-posframe-configure-alist
+;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-bottom-left)))))
+;; ;; (setq ivy-posframe-configure-alist
+;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-point)))))
 ;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 ;; *** Per-command mode.
 ;; #+BEGIN_EXAMPLE
 ;; (require 'ivy-posframe)
 ;; ;; Different command can use different display function.
-;; (push '(counsel-M-x . ivy-posframe-display-at-window-bottom-left) ivy-display-functions-alist)
-;; (push '(complete-symbol . ivy-posframe-display-at-point) ivy-display-functions-alist)
-;; (push '(swiper . ivy-posframe-display-at-point) ivy-display-functions-alist)
+;; (setq ivy-posframe-configure-alist
+;;       '((ivy-display-functions-alist . ((swiper          . ivy-posframe-display-at-point)
+;;                                         (complete-symbol . ivy-posframe-display-at-point)
+;;                                         (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+;;                                         (t               . ivy-posframe-display)))))
+;; (ivy-posframe-mode t)
+;; #+END_EXAMPLE
+;;
+;; You can use ivy original display function on specify function.
+;; You may want to use the original display function because display
+;; of Swiper at point hides the contents of the buffer.
+;; #+BEGIN_EXAMPLE
+;; (require 'ivy-posframe)
+;; ;; Different command can use different display function.
+;; (setq ivy-posframe-configure-alist
+;;       '((ivy-display-functions-alist . ((swiper          . nil)
+;;                                         (complete-symbol . ivy-posframe-display-at-point)
+;;                                         (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+;;                                         (t               . ivy-posframe-display)))))
 ;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 ;;
@@ -81,13 +103,6 @@
 ;; The value of variable `this-command' will be used as the search key
 ;; by ivy to find display function in `ivy-display-functions-alist',
 ;; "C-h v this-command" is a good idea.
-
-;; *** Fallback mode
-;; #+BEGIN_EXAMPLE
-;; (require 'ivy-posframe)
-;; (push '(t . ivy-posframe-display) ivy-display-functions-alist)
-;; (ivy-posframe-mode t)
-;; #+END_EXAMPLE
 
 ;; ** Tips
 
@@ -107,6 +122,7 @@
 ;; #+BEGIN_EXAMPLE
 ;; (defun ivy-posframe-display-at-XXX (str)
 ;;   (ivy-posframe--display str #'your-own-poshandler-function))
+;; (push 'ivy-posframe-display-at-XXX ivy-posframe-display-function-list) ; This line is needed.
 ;; (ivy-posframe-mode t) ; This line is needed.
 ;; #+END_EXAMPLE
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -192,6 +192,11 @@ When 0, no border is showed."
   :group 'ivy-posframe
   :type 'sexp)
 
+(defcustom ivy-posframe-height-alist nil
+  "The `ivy-height-alist' while working ivy-posframe."
+  :group 'ivy-posframe
+  :type 'sexp)
+
 (defcustom ivy-posframe-additional-display-functions nil
   "The additional display functions"
   :group 'ivy-posframe
@@ -461,6 +466,12 @@ selection, non-nil otherwise."
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 
+(defun ivy-posframe--height (fn &rest args)
+  "Around advide of FN with ARGS."
+  (let ((ivy-height-alist
+         (append ivy-posframe-height-alist ivy-height-alist)))
+    (apply fn args)))
+
 ;;; variables
 
 (defvar ivy-posframe-display-function-list
@@ -473,7 +484,8 @@ selection, non-nil otherwise."
 
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
-    (ivy--queue-exhibit    . ivy-posframe--add-prompt)))
+    (ivy--queue-exhibit    . ivy-posframe--add-prompt)
+    (ivy--height           . ivy-posframe--height)))
 
 ;;;###autoload
 (define-minor-mode ivy-posframe-mode

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -471,6 +471,14 @@ selection, non-nil otherwise."
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 
+(defun ivy-posframe--display-function-prop (fn &rest args)
+  "Around advice of FN with ARGS."
+  (let ((ivy-display-functions-props
+         (append ivy-display-functions-props
+                 (mapcar (lambda (elm) `(,elm :cleanup ivy-posframe-cleanup))
+                         ivy-posframe-display-function-list))))
+    (apply fn args)))
+
 (defun ivy-posframe--height (fn &rest args)
   "Around advide of FN with ARGS."
   (let ((ivy-height-alist
@@ -496,6 +504,7 @@ selection, non-nil otherwise."
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
     (ivy--queue-exhibit    . ivy-posframe--add-prompt)
+    (ivy--display-function-prop . ivy-posframe--display-function-prop)
     (ivy--height           . ivy-posframe--height)
     (ivy-read              . ivy-posframe--read)))
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -226,26 +226,28 @@ This variable is useful for `ivy-posframe-read-action' .")
         (funcall func str)
       (ivy-posframe-display-at-frame-bottom-left str))))
 
-(defun ivy-posframe-display-at-window-center (str)
-  (ivy-posframe--display str #'posframe-poshandler-window-center))
+(defvar ivy-posframe-display-functions-alist
+  '((window-center      . window-center)
+    (frame-center       . frame-center)
+    (window-bottom-left . window-bottom-left-corner)
+    (frame-bottom-left  . frame-bottom-left-corner)
+    (point              . point-bottom-left-corner)))
 
-(defun ivy-posframe-display-at-frame-center (str)
-  (ivy-posframe--display str #'posframe-poshandler-frame-center))
-
-(defun ivy-posframe-display-at-window-bottom-left (str)
-  (ivy-posframe--display str #'posframe-poshandler-window-bottom-left-corner))
-
-(defun ivy-posframe-display-at-frame-bottom-left (str)
-  (ivy-posframe--display str #'posframe-poshandler-frame-bottom-left-corner))
+(eval
+ `(progn
+    ,@(mapcar
+       (lambda (elm)
+         `(defun ,(intern (format "ivy-posframe-display-at-%s" (car elm))) (str)
+            ,(format "Display STR via `posframe' at %s." (car elm))
+            (ivy-posframe--display str #',(intern (format "posframe-poshandler-%s" (cdr elm))))))
+       ivy-posframe-display-functions-alist)))
 
 (defun ivy-posframe-display-at-frame-bottom-window-center (str)
+  "Display STR via `posframe' at frame-bottom-window-center."
   (ivy-posframe--display
    str (lambda (info)
          (cons (car (posframe-poshandler-window-center info))
                (cdr (posframe-poshandler-frame-bottom-left-corner info))))))
-
-(defun ivy-posframe-display-at-point (str)
-  (ivy-posframe--display str #'posframe-poshandler-point-bottom-left-corner))
 
 (defun ivy-posframe-cleanup ()
   "Cleanup ivy's posframe."

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -278,14 +278,14 @@ This variable is useful for `ivy-posframe-read-action' .")
     (frame-bottom-left  . frame-bottom-left-corner)
     (point              . point-bottom-left-corner)))
 
-(eval
- `(progn
-    ,@(mapcar
-       (lambda (elm)
-         `(defun ,(intern (format "ivy-posframe-display-at-%s" (car elm))) (str)
-            ,(format "Display STR via `posframe' at %s." (car elm))
-            (ivy-posframe--display str #',(intern (format "posframe-poshandler-%s" (cdr elm))))))
-       ivy-posframe-display-function-alist)))
+(defmacro ivy-posframe-define-display-function (pair)
+  "Define display-function for ivy-posframe."
+  `(defun ,(intern (format "ivy-posframe-display-at-%s" (car pair))) (str)
+     ,(format "Display STR via `posframe' at %s." (car pair))
+     (ivy-posframe--display str #',(intern (format "posframe-poshandler-%s" (cdr pair))))))
+
+(mapc (lambda (elm) (ivy-posframe-define-display-function elm))
+      ivy-posframe-display-function-alist)
 
 (defun ivy-posframe-display-at-frame-bottom-window-center (str)
   "Display STR via `posframe' at frame-bottom-window-center."

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -439,9 +439,17 @@ selection, non-nil otherwise."
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 
+;;; variables
+
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
     (ivy--queue-exhibit    . ivy-posframe--add-prompt)))
+
+(defvar ivy-posframe-keybind-list
+  '((ivy-minibuffer-map [remap ivy-read-action] ivy-posframe-read-action)
+    (ivy-minibuffer-map [remap ivy-dispatching-done] ivy-posframe-dispatching-done)
+    (ivy-minibuffer-map [remap ivy-avy] ivy-posframe-avy)
+    (ivy-minibuffer-map [remap swiper-avy] ivy-posframe-swiper-avy)))
 
 ;;;###autoload
 (defun ivy-posframe-enable ()
@@ -454,13 +462,11 @@ selection, non-nil otherwise."
               ivy-posframe-display-functions)
       (mapcar (lambda (elm)
                 `(advice-add ',(car elm) :around #',(cdr elm)))
-              ivy-posframe-advice-alist)))
-  (define-key ivy-minibuffer-map
-    [remap ivy-read-action] 'ivy-posframe-read-action)
-  (define-key ivy-minibuffer-map
-    [remap ivy-dispatching-done] 'ivy-posframe-dispatching-done)
-  (define-key ivy-minibuffer-map [remap ivy-avy] 'ivy-posframe-avy)
-  (define-key ivy-minibuffer-map [remap swiper-avy] 'ivy-posframe-swiper-avy)
+              ivy-posframe-advice-alist)
+      (mapcar (lambda (elm)
+                (let ((map (nth 0 elm)) (key (nth 1 elm)) (cmd (nth 2 elm)))
+                  `(define-key ,map ,key ',cmd)))
+              ivy-posframe-keybind-list)))
   (message "ivy-posframe is enabled, disabling it need to reboot emacs."))
 
 ;;;###autoload

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -466,7 +466,12 @@ selection, non-nil otherwise."
          `(progn
             (mapcar (lambda (elm) `(push `(,elm :cleanup ivy-posframe-cleanup) ivy-display-functions-props)) fncs)
             (mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) vars)
-            (mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) ',(nth 2 elm)) keys)))))))
+            (mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) ',(nth 2 elm)) keys))))
+      (eval
+       `(progn
+          (mapcar (lambda (elm) `(push `(,elm :cleanup ignore) ivy-display-functions-props)) fncs)
+          (mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) vars)
+          (mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) nil) keys)))))))
 
 ;;;###autoload
 (defun ivy-posframe-demo ()

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -217,7 +217,7 @@ This variable is useful for `ivy-posframe-read-action' .")
        :internal-border-width ivy-posframe-border-width
        :internal-border-color (face-attribute 'ivy-posframe-border :background nil t)
        :override-parameters ivy-posframe-parameters))
-    (ivy-posframe--add-prompt)))
+    (ivy-posframe--add-prompt 'ignore)))
 
 (defun ivy-posframe-display (str)
   "Display STR via `posframe' by `ivy-posframe-style'."
@@ -461,14 +461,14 @@ selection, non-nil otherwise."
     (if ivy-posframe-mode
         (eval
          `(progn
-            (mapcar (lambda (elm) `(push `(,elm :cleanup ivy-posframe-cleanup) ivy-display-functions-props)) fncs)
-            (mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) vars)
-            (mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) ',(nth 2 elm)) keys))))
+            ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ivy-posframe-cleanup) ivy-display-functions-props)) fncs)
+            ,@(mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) advs)
+            ,@(mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) ',(nth 2 elm))) keys)))
       (eval
        `(progn
-          (mapcar (lambda (elm) `(push `(,elm :cleanup ignore) ivy-display-functions-props)) fncs)
-          (mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) vars)
-          (mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) nil) keys)))))))
+          ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ignore) ivy-display-functions-props)) fncs)
+          ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advs)
+          ,@(mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) nil)) keys))))))
 
 ;;;###autoload
 (defun ivy-posframe-demo ()

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -535,6 +535,9 @@ selection, non-nil otherwise."
           ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advices))))))
 
 ;;;###autoload
+(defalias 'ivy-posframe-enable 'ivy-posframe-mode)
+
+;;;###autoload
 (defun ivy-posframe-demo ()
   "Toggle a demo config of ivy-posframe.
 This function is ONLY used to test ivy-posframe."

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -434,6 +434,13 @@ selection, non-nil otherwise."
 
 ;;; variables
 
+(defvar ivy-posframe-display-function-list
+  (append
+   (mapcar (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
+           ivy-posframe-display-functions-alist))
+  '(ivy-posframe-display
+    ivy-posframe-display-at-frame-bottom-window-center))
+
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
     (ivy--queue-exhibit    . ivy-posframe--add-prompt)))
@@ -451,11 +458,7 @@ selection, non-nil otherwise."
   :global t
   :lighter " ivy-pf"
   :group 'ivy-posframe
-  (let ((fncs (append (mapcar
-                       (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
-                       ivy-posframe-display-functions-alist)
-                      '(ivy-posframe-display
-                        ivy-posframe-display-at-frame-bottom-window-center)))
+  (let ((fncs ivy-posframe-display-function-list)
         (advs ivy-posframe-advice-alist)
         (keys ivy-posframe-keybind-list))
     (if ivy-posframe-mode

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -500,7 +500,6 @@ selection, non-nil otherwise."
        `(progn
           ,@(mapcan
              (lambda (conf) (mapcar (lambda (elm) `(setq ,(car conf) (remove ',elm ,(car conf)))) (cdr conf))) configures)
-          ,@(mapcar (lambda (elm) `(setq ivy-display-functions-alist (delete ',elm ivy-display-functions-alist))) configures)
           ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ignore) ivy-display-functions-props)) fncs)
           ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advs))))))
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -272,17 +272,17 @@ This variable is useful for `ivy-posframe-read-action' .")
       (ivy-posframe-display-at-frame-bottom-left str))))
 
 (defvar ivy-posframe-display-function-alist
-  '((window-center      . window-center)
-    (frame-center       . frame-center)
-    (window-bottom-left . window-bottom-left-corner)
-    (frame-bottom-left  . frame-bottom-left-corner)
-    (point              . point-bottom-left-corner)))
+  '((window-center      . posframe-poshandler-window-center)
+    (frame-center       . posframe-poshandler-frame-center)
+    (window-bottom-left . posframe-poshandler-window-bottom-left-corner)
+    (frame-bottom-left  . posframe-poshandler-frame-bottom-left-corner)
+    (point              . posframe-poshandler-point-bottom-left-corner)))
 
 (defmacro ivy-posframe-define-display-function (pair)
   "Define display-function for ivy-posframe."
   `(defun ,(intern (format "ivy-posframe-display-at-%s" (car pair))) (str)
      ,(format "Display STR via `posframe' at %s." (car pair))
-     (ivy-posframe--display str #',(intern (format "posframe-poshandler-%s" (cdr pair))))))
+     (ivy-posframe--display str #',(cdr pair))))
 
 (mapc (lambda (elm) (ivy-posframe-define-display-function elm))
       ivy-posframe-display-function-alist)

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -409,6 +409,8 @@ selection, non-nil otherwise."
         (ivy-quit-and-run
           (avy-action-goto (avy-candidate-beg candidate)))))))
 
+;;; Advice
+
 (defun ivy-posframe--minibuffer-setup (orig-func)
   "Advice function of `ivy--minibuffer-setup'."
   (let ((ivy-fixed-height-minibuffer nil))
@@ -435,6 +437,10 @@ selection, non-nil otherwise."
           (delete-region (point) (save-excursion (line-move 1 'noerror) (point)))
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
+
+(defvar ivy-posframe-advice-alist
+  '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
+    (ivy--queue-exhibit    . ivy-posframe--add-prompt)))
 
 ;;;###autoload
 (defun ivy-posframe-enable ()

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -268,19 +268,6 @@ This variable is useful for `ivy-posframe-read-action' .")
   (when (ivy-posframe-read-action)
     (ivy-done)))
 
-(defun ivy-posframe--add-prompt ()
-  "Add the ivy prompt to the posframe."
-  (unless ivy-posframe--ignore-prompt
-    (with-current-buffer (window-buffer (active-minibuffer-window))
-      (let ((point (point))
-            (prompt (buffer-string)))
-        (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
-        (with-current-buffer ivy-posframe-buffer
-          (goto-char (point-min))
-          (delete-region (point) (save-excursion (line-move 1 'noerror) (point)))
-          (insert prompt "  \n")
-          (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
-
 (defun ivy-posframe-read-action ()
   "Change the action to one of the available ones.
 
@@ -435,6 +422,19 @@ selection, non-nil otherwise."
                    (let ((bg-color (face-background 'default nil)))
                      `(:background ,bg-color :foreground ,bg-color)))
       (setq-local cursor-type nil))))
+
+(defun ivy-posframe--add-prompt ()
+  "Add the ivy prompt to the posframe."
+  (unless ivy-posframe--ignore-prompt
+    (with-current-buffer (window-buffer (active-minibuffer-window))
+      (let ((point (point))
+            (prompt (buffer-string)))
+        (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
+        (with-current-buffer ivy-posframe-buffer
+          (goto-char (point-min))
+          (delete-region (point) (save-excursion (line-move 1 'noerror) (point)))
+          (insert prompt "  \n")
+          (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 
 ;;;###autoload
 (defun ivy-posframe-enable ()

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -54,29 +54,23 @@
 ;; *** Global mode
 ;; #+BEGIN_EXAMPLE
 ;; (require 'ivy-posframe)
-;; (setq ivy-posframe-configure-alist
-;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display)))))
-;; ;; (setq ivy-posframe-configure-alist
-;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-center)))))
-;; ;; (setq ivy-posframe-configure-alist
-;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-center)))))
-;; ;; (setq ivy-posframe-configure-alist
-;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-frame-bottom-left)))))
-;; ;; (setq ivy-posframe-configure-alist
-;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-window-bottom-left)))))
-;; ;; (setq ivy-posframe-configure-alist
-;; ;;       '((ivy-display-functions-alist . ((t . ivy-posframe-display-at-point)))))
+;; ;; display at `ivy-posframe-style'
+;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display)))
+;; ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-frame-center)))
+;; ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-window-center)))
+;; ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-frame-bottom-left)))
+;; ;; (setq ivy-posframe-display-functions-alist '((t . ivy-posframe-display-at-window-bottom-left)))
 ;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 ;; *** Per-command mode.
 ;; #+BEGIN_EXAMPLE
 ;; (require 'ivy-posframe)
 ;; ;; Different command can use different display function.
-;; (setq ivy-posframe-configure-alist
-;;       '((ivy-display-functions-alist . ((swiper          . ivy-posframe-display-at-point)
-;;                                         (complete-symbol . ivy-posframe-display-at-point)
-;;                                         (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
-;;                                         (t               . ivy-posframe-display)))))
+;; (setq ivy-posframe-display-functions-alist
+;;       '((swiper          . ivy-posframe-display-at-point)
+;;         (complete-symbol . ivy-posframe-display-at-point)
+;;         (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+;;         (t               . ivy-posframe-display)))
 ;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 ;;
@@ -86,11 +80,31 @@
 ;; #+BEGIN_EXAMPLE
 ;; (require 'ivy-posframe)
 ;; ;; Different command can use different display function.
-;; (setq ivy-posframe-configure-alist
-;;       '((ivy-display-functions-alist . ((swiper          . nil)
-;;                                         (complete-symbol . ivy-posframe-display-at-point)
-;;                                         (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
-;;                                         (t               . ivy-posframe-display)))))
+;; (setq ivy-posframe-display-functions-alist
+;;       '((swiper          . nil)
+;;         (complete-symbol . ivy-posframe-display-at-point)
+;;         (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+;;         (t               . ivy-posframe-display)))
+;; (ivy-posframe-mode t)
+;; #+END_EXAMPLE
+;;
+;; You may want to change the height of ivy by a function only while
+;; using posframe. This is possible with the code below.
+;;
+;; The following example displays swiper on 20 lines by default for ivy,
+;; and displays other functions in posframe at the location specified on
+;; 40 lines.
+;; #+BEGIN_EXAMPLE
+;; (require 'ivy-posframe)
+;; ;; Different command can use different display function.
+;; (setq ivy-posframe-height-alist '((swiper . 20)
+;;                                   (t      . 40)))
+;;
+;; (setq ivy-posframe-display-functions-alist
+;;       '((swiper          . nil)
+;;         (complete-symbol . ivy-posframe-display-at-point)
+;;         (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
+;;         (t               . ivy-posframe-display)))
 ;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 ;;

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -184,14 +184,6 @@ When 0, no border is showed."
   :group 'ivy-posframe
   :type 'string)
 
-(defcustom ivy-posframe-configure-alist
-  `(,@(when ivy-posframe-height
-        `(ivy-height-alist . ((t . ,ivy-posframe-height))))
-    (ivy-display-functions-alist . ((t . ivy-posframe-display))))
-  "The ivy configuration alist."
-  :group 'ivy-posframe
-  :type 'sexp)
-
 (defcustom ivy-posframe-height-alist nil
   "The `ivy-height-alist' while working ivy-posframe."
   :group 'ivy-posframe

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -197,6 +197,11 @@ When 0, no border is showed."
   :group 'ivy-posframe
   :type 'sexp)
 
+(defcustom ivy-posframe-display-functions-alist '((t . ivy-posframe-display))
+  "The `ivy-display-functions-alist' while working ivy-posframe."
+  :group 'ivy-posframe
+  :type 'sexp)
+
 (defcustom ivy-posframe-additional-display-functions nil
   "The additional display functions"
   :group 'ivy-posframe
@@ -472,6 +477,12 @@ selection, non-nil otherwise."
          (append ivy-posframe-height-alist ivy-height-alist)))
     (apply fn args)))
 
+(defun ivy-posframe--read (fn &rest args)
+  "Around advice of FN with AGS."
+  (let ((ivy-display-functions-alist
+         (append ivy-posframe-display-functions-alist ivy-display-functions-alist)))
+    (apply fn args)))
+
 ;;; variables
 
 (defvar ivy-posframe-display-function-list
@@ -485,7 +496,8 @@ selection, non-nil otherwise."
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
     (ivy--queue-exhibit    . ivy-posframe--add-prompt)
-    (ivy--height           . ivy-posframe--height)))
+    (ivy--height           . ivy-posframe--height)
+    (ivy-read              . ivy-posframe--read)))
 
 ;;;###autoload
 (define-minor-mode ivy-posframe-mode

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -247,6 +247,15 @@ This variable is useful for `ivy-posframe-read-action' .")
 (defun ivy-posframe-display-at-point (str)
   (ivy-posframe--display str #'posframe-poshandler-point-bottom-left-corner))
 
+(defvar ivy-posframe-display-functions
+  '(ivy-posframe-display
+    ivy-posframe-display-at-window-center
+    ivy-posframe-display-at-frame-center
+    ivy-posframe-display-at-window-bottom-left
+    ivy-posframe-display-at-frame-bottom-left
+    ivy-posframe-display-at-frame-bottom-window-center
+    ivy-posframe-display-at-point))
+
 (defun ivy-posframe-cleanup ()
   "Cleanup ivy's posframe."
   (when (posframe-workable-p)
@@ -431,15 +440,11 @@ selection, non-nil otherwise."
 (defun ivy-posframe-enable ()
   "Enable ivy-posframe."
   (interactive)
-  ;; Add all display functions of ivy-posframe to
-  ;; `ivy-display-functions-props'.
-  (mapatoms
-   (lambda (func)
-     (when (and (functionp func)
-                (string-match-p "^ivy-posframe-display" (symbol-name func))
-                (not (assq func ivy-display-functions-props)))
-       (push `(,func :cleanup ivy-posframe-cleanup)
-             ivy-display-functions-props))))
+  (eval
+   `(progn
+      (mapcar (lambda (fn)
+                `(push `(,fn :cleanup ivy-posframe-cleanup) ivy-display-functions-props))
+              ivy-posframe-display-functions)))
   (define-key ivy-minibuffer-map
     [remap ivy-read-action] 'ivy-posframe-read-action)
   (define-key ivy-minibuffer-map

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -475,12 +475,6 @@ selection, non-nil otherwise."
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
     (ivy--queue-exhibit    . ivy-posframe--add-prompt)))
 
-(defvar ivy-posframe-keybind-list
-  '((ivy-minibuffer-map [remap ivy-read-action] ivy-posframe-read-action)
-    (ivy-minibuffer-map [remap ivy-dispatching-done] ivy-posframe-dispatching-done)
-    (ivy-minibuffer-map [remap ivy-avy] ivy-posframe-avy)
-    (ivy-minibuffer-map [remap swiper-avy] ivy-posframe-swiper-avy)))
-
 ;;;###autoload
 (define-minor-mode ivy-posframe-mode
   "Display ivy via posframe."
@@ -488,9 +482,12 @@ selection, non-nil otherwise."
   :global t
   :lighter " ivy-pf"
   :group 'ivy-posframe
+  :keymap '(([remap ivy-read-action] ivy-posframe-read-action)
+            ([remap ivy-dispatching-done] ivy-posframe-dispatching-done)
+            ([remap ivy-avy] ivy-posframe-avy)
+            ([remap swiper-avy] ivy-posframe-swiper-avy))
   (let ((fncs ivy-posframe-display-function-list)
         (advs ivy-posframe-advice-alist)
-        (keys ivy-posframe-keybind-list)
         (configures ivy-posframe-configure-alist))
     (if ivy-posframe-mode
         (eval
@@ -498,16 +495,14 @@ selection, non-nil otherwise."
             ,@(mapcan
                (lambda (conf) (mapcar (lambda (elm) `(push ',elm ,(car conf))) (cdr conf))) configures)
             ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ivy-posframe-cleanup) ivy-display-functions-props)) fncs)
-            ,@(mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) advs)
-            ,@(mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) ',(nth 2 elm))) keys)))
+            ,@(mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) advs)))
       (eval
        `(progn
           ,@(mapcan
              (lambda (conf) (mapcar (lambda (elm) `(setq ,(car conf) (remove ',elm ,(car conf)))) (cdr conf))) configures)
           ,@(mapcar (lambda (elm) `(setq ivy-display-functions-alist (delete ',elm ivy-display-functions-alist))) configures)
           ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ignore) ivy-display-functions-props)) fncs)
-          ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advs)
-          ,@(mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) nil)) keys))))))
+          ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advs))))))
 
 ;;;###autoload
 (defun ivy-posframe-demo ()

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -176,6 +176,11 @@ When 0, no border is showed."
   :group 'ivy-posframe
   :type 'sexp)
 
+(defcustom ivy-posframe-additional-display-functions nil
+  "The additional display functions"
+  :group 'ivy-posframe
+  :type 'sexp)
+
 (defface ivy-posframe
   '((t (:inherit default)))
   "Face used by the ivy-posframe."
@@ -444,10 +449,11 @@ selection, non-nil otherwise."
 
 (defvar ivy-posframe-display-function-list
   (append
+   ivy-posframe-additional-display-functions
    (mapcar (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
-           ivy-posframe-display-function-alist))
-  '(ivy-posframe-display
-    ivy-posframe-display-at-frame-bottom-window-center))
+           ivy-posframe-display-function-alist)
+   '(ivy-posframe-display
+     ivy-posframe-display-at-frame-bottom-window-center)))
 
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -458,19 +458,15 @@ selection, non-nil otherwise."
   :global t
   :lighter " ivy-pf"
   :group 'ivy-posframe
-  (if ivy-posframe-mode
-      (eval
-       `(progn
-          (mapcar (lambda (fn)
-                    `(push `(,fn :cleanup ivy-posframe-cleanup) ivy-display-functions-props))
-                  ivy-posframe-display-functions)
-          (mapcar (lambda (elm)
-                    `(advice-add ',(car elm) :around #',(cdr elm)))
-                  ivy-posframe-advice-alist)
-          (mapcar (lambda (elm)
-                    (let ((map (nth 0 elm)) (key (nth 1 elm)) (cmd (nth 2 elm)))
-                      `(define-key ,map ,key ',cmd)))
-                  ivy-posframe-keybind-list)))))
+  (let ((fncs ivy-posframe-display-functions)
+        (advs ivy-posframe-advice-alist)
+        (keys ivy-posframe-keybind-list))
+    (if ivy-posframe-mode
+        (eval
+         `(progn
+            (mapcar (lambda (elm) `(push `(,elm :cleanup ivy-posframe-cleanup) ivy-display-functions-props)) fncs)
+            (mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) vars)
+            (mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) ',(nth 2 elm)) keys)))))))
 
 ;;;###autoload
 (defun ivy-posframe-demo ()

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -411,10 +411,10 @@ selection, non-nil otherwise."
 
 ;;; Advice
 
-(defun ivy-posframe--minibuffer-setup (orig-func)
+(defun ivy-posframe--minibuffer-setup (fn &rest args)
   "Advice function of `ivy--minibuffer-setup'."
   (let ((ivy-fixed-height-minibuffer nil))
-    (funcall orig-func))
+    (apply fn args))
   (when (and ivy-posframe-hide-minibuffer
              ;; only hide minibuffer's info when posframe is showed.
              ivy-posframe--display-p)
@@ -425,8 +425,9 @@ selection, non-nil otherwise."
                      `(:background ,bg-color :foreground ,bg-color)))
       (setq-local cursor-type nil))))
 
-(defun ivy-posframe--add-prompt ()
+(defun ivy-posframe--add-prompt (fn &rest args)
   "Add the ivy prompt to the posframe."
+  (apply fn args)
   (unless ivy-posframe--ignore-prompt
     (with-current-buffer (window-buffer (active-minibuffer-window))
       (let ((point (point))
@@ -458,7 +459,7 @@ selection, non-nil otherwise."
   (define-key ivy-minibuffer-map [remap ivy-avy] 'ivy-posframe-avy)
   (define-key ivy-minibuffer-map [remap swiper-avy] 'ivy-posframe-swiper-avy)
   (advice-add 'ivy--minibuffer-setup :around #'ivy-posframe--minibuffer-setup)
-  (advice-add 'ivy--queue-exhibit :after #'ivy-posframe--add-prompt)
+  (advice-add 'ivy--queue-exhibit :around #'ivy-posframe--add-prompt)
   (message "ivy-posframe is enabled, disabling it need to reboot emacs."))
 
 ;;;###autoload

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -271,28 +271,34 @@ This variable is useful for `ivy-posframe-read-action' .")
         (funcall func str)
       (ivy-posframe-display-at-frame-bottom-left str))))
 
-(defvar ivy-posframe-display-function-alist
-  '((window-center      . posframe-poshandler-window-center)
-    (frame-center       . posframe-poshandler-frame-center)
-    (window-bottom-left . posframe-poshandler-window-bottom-left-corner)
-    (frame-bottom-left  . posframe-poshandler-frame-bottom-left-corner)
-    (point              . posframe-poshandler-point-bottom-left-corner)))
+(defun ivy-posframe-display-at-window-center (str)
+  (ivy-posframe--display str #'posframe-poshandler-window-center))
 
-(defmacro ivy-posframe-define-display-function (pair)
-  "Define display-function for ivy-posframe."
-  `(defun ,(intern (format "ivy-posframe-display-at-%s" (car pair))) (str)
-     ,(format "Display STR via `posframe' at %s." (car pair))
-     (ivy-posframe--display str #',(cdr pair))))
+(defun ivy-posframe-display-at-frame-center (str)
+  (ivy-posframe--display str #'posframe-poshandler-frame-center))
 
-(mapc (lambda (elm) (ivy-posframe-define-display-function elm))
-      ivy-posframe-display-function-alist)
+(defun ivy-posframe-display-at-window-bottom-left (str)
+  (ivy-posframe--display str #'posframe-poshandler-window-bottom-left-corner))
+
+(defun ivy-posframe-display-at-frame-bottom-left (str)
+  (ivy-posframe--display str #'posframe-poshandler-frame-bottom-left-corner))
 
 (defun ivy-posframe-display-at-frame-bottom-window-center (str)
-  "Display STR via `posframe' at frame-bottom-window-center."
   (ivy-posframe--display
    str (lambda (info)
          (cons (car (posframe-poshandler-window-center info))
                (cdr (posframe-poshandler-frame-bottom-left-corner info))))))
+
+(defun ivy-posframe-display-at-point (str)
+  (ivy-posframe--display str #'posframe-poshandler-point-bottom-left-corner))
+
+(defvar ivy-posframe-display-function-list '(ivy-posframe-display
+                                             ivy-posframe-display-at-window-center
+                                             ivy-posframe-display-at-frame-center
+                                             ivy-posframe-display-at-window-bottom-left
+                                             ivy-posframe-display-at-frame-bottom-left
+                                             ivy-posframe-display-at-frame-bottom-window-center
+                                             ivy-posframe-display-at-point))
 
 (defun ivy-posframe-cleanup ()
   "Cleanup ivy's posframe."
@@ -450,12 +456,7 @@ selection, non-nil otherwise."
 ;;; Variables
 
 (defvar ivy-posframe-display-function-list
-  (append
-   ivy-posframe-additional-display-functions
-   (mapcar (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
-           ivy-posframe-display-function-alist)
-   '(ivy-posframe-display
-     ivy-posframe-display-at-frame-bottom-window-center)))
+  (append ivy-posframe-additional-display-functions ivy-posframe-display-function-list))
 
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup      . ivy-posframe--minibuffer-setup)

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -60,7 +60,7 @@
 ;; ;; (setq ivy-display-function #'ivy-posframe-display-at-frame-bottom-left)
 ;; ;; (setq ivy-display-function #'ivy-posframe-display-at-window-bottom-left)
 ;; ;; (setq ivy-display-function #'ivy-posframe-display-at-point)
-;; (ivy-posframe-enable)
+;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 ;; *** Per-command mode.
 ;; #+BEGIN_EXAMPLE
@@ -69,7 +69,7 @@
 ;; (push '(counsel-M-x . ivy-posframe-display-at-window-bottom-left) ivy-display-functions-alist)
 ;; (push '(complete-symbol . ivy-posframe-display-at-point) ivy-display-functions-alist)
 ;; (push '(swiper . ivy-posframe-display-at-point) ivy-display-functions-alist)
-;; (ivy-posframe-enable)
+;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 ;;
 ;; NOTE: Using swiper as example: swiper's display function *only*
@@ -86,7 +86,7 @@
 ;; #+BEGIN_EXAMPLE
 ;; (require 'ivy-posframe)
 ;; (push '(t . ivy-posframe-display) ivy-display-functions-alist)
-;; (ivy-posframe-enable)
+;; (ivy-posframe-mode t)
 ;; #+END_EXAMPLE
 
 ;; ** Tips
@@ -107,7 +107,7 @@
 ;; #+BEGIN_EXAMPLE
 ;; (defun ivy-posframe-display-at-XXX (str)
 ;;   (ivy-posframe--display str #'your-own-poshandler-function))
-;; (ivy-posframe-enable) ; This line is needed.
+;; (ivy-posframe-mode t) ; This line is needed.
 ;; #+END_EXAMPLE
 
 ;;; Code:
@@ -452,29 +452,32 @@ selection, non-nil otherwise."
     (ivy-minibuffer-map [remap swiper-avy] ivy-posframe-swiper-avy)))
 
 ;;;###autoload
-(defun ivy-posframe-enable ()
-  "Enable ivy-posframe."
-  (interactive)
-  (eval
-   `(progn
-      (mapcar (lambda (fn)
-                `(push `(,fn :cleanup ivy-posframe-cleanup) ivy-display-functions-props))
-              ivy-posframe-display-functions)
-      (mapcar (lambda (elm)
-                `(advice-add ',(car elm) :around #',(cdr elm)))
-              ivy-posframe-advice-alist)
-      (mapcar (lambda (elm)
-                (let ((map (nth 0 elm)) (key (nth 1 elm)) (cmd (nth 2 elm)))
-                  `(define-key ,map ,key ',cmd)))
-              ivy-posframe-keybind-list)))
-  (message "ivy-posframe is enabled, disabling it need to reboot emacs."))
+(define-minor-mode ivy-posframe-mode
+  "Display ivy via posframe."
+  :init-value nil
+  :global t
+  :lighter " ivy-pf"
+  :group 'ivy-posframe
+  (if ivy-posframe-mode
+      (eval
+       `(progn
+          (mapcar (lambda (fn)
+                    `(push `(,fn :cleanup ivy-posframe-cleanup) ivy-display-functions-props))
+                  ivy-posframe-display-functions)
+          (mapcar (lambda (elm)
+                    `(advice-add ',(car elm) :around #',(cdr elm)))
+                  ivy-posframe-advice-alist)
+          (mapcar (lambda (elm)
+                    (let ((map (nth 0 elm)) (key (nth 1 elm)) (cmd (nth 2 elm)))
+                      `(define-key ,map ,key ',cmd)))
+                  ivy-posframe-keybind-list)))))
 
 ;;;###autoload
 (defun ivy-posframe-demo ()
   "Toggle a demo config of ivy-posframe.
 This function is ONLY used to test ivy-posframe."
   (interactive)
-  (ivy-posframe-enable)
+  (ivy-posframe-mode t)
   (let ((config '(t . ivy-posframe-display-at-frame-center)))
     (if (member config ivy-display-functions-alist)
         (progn

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -527,12 +527,8 @@ selection, non-nil otherwise."
             ([remap swiper-avy] ivy-posframe-swiper-avy))
   (let ((advices ivy-posframe-advice-alist))
     (if ivy-posframe-mode
-        (eval
-         `(progn
-            ,@(mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) advices)))
-      (eval
-       `(progn
-          ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advices))))))
+        (mapcar (lambda (elm) (advice-add (car elm) :around (cdr elm))) advices)
+      (mapcar (lambda (elm) (advice-remove (car elm) (cdr elm))) advices))))
 
 ;;;###autoload
 (defalias 'ivy-posframe-enable 'ivy-posframe-mode)

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -247,15 +247,6 @@ This variable is useful for `ivy-posframe-read-action' .")
 (defun ivy-posframe-display-at-point (str)
   (ivy-posframe--display str #'posframe-poshandler-point-bottom-left-corner))
 
-(defvar ivy-posframe-display-functions
-  '(ivy-posframe-display
-    ivy-posframe-display-at-window-center
-    ivy-posframe-display-at-frame-center
-    ivy-posframe-display-at-window-bottom-left
-    ivy-posframe-display-at-frame-bottom-left
-    ivy-posframe-display-at-frame-bottom-window-center
-    ivy-posframe-display-at-point))
-
 (defun ivy-posframe-cleanup ()
   "Cleanup ivy's posframe."
   (when (posframe-workable-p)
@@ -440,6 +431,15 @@ selection, non-nil otherwise."
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 
 ;;; variables
+
+(defvar ivy-posframe-display-functions
+  '(ivy-posframe-display
+    ivy-posframe-display-at-window-center
+    ivy-posframe-display-at-frame-center
+    ivy-posframe-display-at-window-bottom-left
+    ivy-posframe-display-at-frame-bottom-left
+    ivy-posframe-display-at-frame-bottom-window-center
+    ivy-posframe-display-at-point))
 
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -441,6 +441,23 @@ selection, non-nil otherwise."
         (ivy-quit-and-run
           (avy-action-goto (avy-candidate-beg candidate)))))))
 
+;;; Variables
+
+(defvar ivy-posframe-display-function-list
+  (append
+   ivy-posframe-additional-display-functions
+   (mapcar (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
+           ivy-posframe-display-function-alist)
+   '(ivy-posframe-display
+     ivy-posframe-display-at-frame-bottom-window-center)))
+
+(defvar ivy-posframe-advice-alist
+  '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
+    (ivy--queue-exhibit    . ivy-posframe--add-prompt)
+    (ivy--display-function-prop . ivy-posframe--display-function-prop)
+    (ivy--height           . ivy-posframe--height)
+    (ivy-read              . ivy-posframe--read)))
+
 ;;; Advice
 
 (defun ivy-posframe--minibuffer-setup (fn &rest args)
@@ -490,23 +507,6 @@ selection, non-nil otherwise."
   (let ((ivy-display-functions-alist
          (append ivy-posframe-display-functions-alist ivy-display-functions-alist)))
     (apply fn args)))
-
-;;; variables
-
-(defvar ivy-posframe-display-function-list
-  (append
-   ivy-posframe-additional-display-functions
-   (mapcar (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
-           ivy-posframe-display-function-alist)
-   '(ivy-posframe-display
-     ivy-posframe-display-at-frame-bottom-window-center)))
-
-(defvar ivy-posframe-advice-alist
-  '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
-    (ivy--queue-exhibit    . ivy-posframe--add-prompt)
-    (ivy--display-function-prop . ivy-posframe--display-function-prop)
-    (ivy--height           . ivy-posframe--height)
-    (ivy-read              . ivy-posframe--read)))
 
 ;;;###autoload
 (define-minor-mode ivy-posframe-mode

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -226,7 +226,7 @@ This variable is useful for `ivy-posframe-read-action' .")
         (funcall func str)
       (ivy-posframe-display-at-frame-bottom-left str))))
 
-(defvar ivy-posframe-display-functions-alist
+(defvar ivy-posframe-display-function-alist
   '((window-center      . window-center)
     (frame-center       . frame-center)
     (window-bottom-left . window-bottom-left-corner)
@@ -240,7 +240,7 @@ This variable is useful for `ivy-posframe-read-action' .")
          `(defun ,(intern (format "ivy-posframe-display-at-%s" (car elm))) (str)
             ,(format "Display STR via `posframe' at %s." (car elm))
             (ivy-posframe--display str #',(intern (format "posframe-poshandler-%s" (cdr elm))))))
-       ivy-posframe-display-functions-alist)))
+       ivy-posframe-display-function-alist)))
 
 (defun ivy-posframe-display-at-frame-bottom-window-center (str)
   "Display STR via `posframe' at frame-bottom-window-center."
@@ -437,7 +437,7 @@ selection, non-nil otherwise."
 (defvar ivy-posframe-display-function-list
   (append
    (mapcar (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
-           ivy-posframe-display-functions-alist))
+           ivy-posframe-display-function-alist))
   '(ivy-posframe-display
     ivy-posframe-display-at-frame-bottom-window-center))
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -431,7 +431,6 @@ selection, non-nil otherwise."
 (defun ivy-posframe-enable ()
   "Enable ivy-posframe."
   (interactive)
-  (require 'ivy)
   ;; Add all display functions of ivy-posframe to
   ;; `ivy-display-functions-props'.
   (mapatoms

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -191,13 +191,13 @@ When 0, no border is showed."
 This variable is useful for `ivy-posframe-read-action' .")
 
 (defvar ivy-posframe--display-p nil
-  "The status of `ivy-posframe--display'")
+  "The status of `ivy-posframe--display'.")
 
 ;; Fix warn
 (defvar emacs-basic-display)
 
 (defun ivy-posframe--display (str &optional poshandler)
-  "Show STR in ivy's posframe."
+  "Show STR in ivy's posframe with POSHANDLER."
   (if (not (posframe-workable-p))
       (ivy-display-function-fallback str)
     (setq ivy-posframe--display-p t)
@@ -220,8 +220,8 @@ This variable is useful for `ivy-posframe-read-action' .")
     (ivy-posframe--add-prompt)))
 
 (defun ivy-posframe-display (str)
-  (let ((func (intern (format "ivy-posframe-display-at-%s"
-                              ivy-posframe-style))))
+  "Display STR via `posframe' by `ivy-posframe-style'."
+  (let ((func (intern (format "ivy-posframe-display-at-%s" ivy-posframe-style))))
     (if (functionp func)
         (funcall func str)
       (ivy-posframe-display-at-frame-bottom-left str))))
@@ -405,7 +405,7 @@ selection, non-nil otherwise."
 ;;; Advice
 
 (defun ivy-posframe--minibuffer-setup (fn &rest args)
-  "Advice function of `ivy--minibuffer-setup'."
+  "Advice function of FN, `ivy--minibuffer-setup' with ARGS."
   (let ((ivy-fixed-height-minibuffer nil))
     (apply fn args))
   (when (and ivy-posframe-hide-minibuffer
@@ -419,7 +419,7 @@ selection, non-nil otherwise."
       (setq-local cursor-type nil))))
 
 (defun ivy-posframe--add-prompt (fn &rest args)
-  "Add the ivy prompt to the posframe."
+  "Add the ivy prompt to the posframe.  Advice FN with ARGS."
   (apply fn args)
   (unless ivy-posframe--ignore-prompt
     (with-current-buffer (window-buffer (active-minibuffer-window))

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -452,11 +452,11 @@ selection, non-nil otherwise."
      ivy-posframe-display-at-frame-bottom-window-center)))
 
 (defvar ivy-posframe-advice-alist
-  '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
-    (ivy--queue-exhibit    . ivy-posframe--add-prompt)
+  '((ivy--minibuffer-setup      . ivy-posframe--minibuffer-setup)
+    (ivy--queue-exhibit         . ivy-posframe--add-prompt)
     (ivy--display-function-prop . ivy-posframe--display-function-prop)
-    (ivy--height           . ivy-posframe--height)
-    (ivy-read              . ivy-posframe--read)))
+    (ivy--height                . ivy-posframe--height)
+    (ivy-read                   . ivy-posframe--read)))
 
 ;;; Advice
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -451,15 +451,16 @@ selection, non-nil otherwise."
    `(progn
       (mapcar (lambda (fn)
                 `(push `(,fn :cleanup ivy-posframe-cleanup) ivy-display-functions-props))
-              ivy-posframe-display-functions)))
+              ivy-posframe-display-functions)
+      (mapcar (lambda (elm)
+                `(advice-add ',(car elm) :around #',(cdr elm)))
+              ivy-posframe-advice-alist)))
   (define-key ivy-minibuffer-map
     [remap ivy-read-action] 'ivy-posframe-read-action)
   (define-key ivy-minibuffer-map
     [remap ivy-dispatching-done] 'ivy-posframe-dispatching-done)
   (define-key ivy-minibuffer-map [remap ivy-avy] 'ivy-posframe-avy)
   (define-key ivy-minibuffer-map [remap swiper-avy] 'ivy-posframe-swiper-avy)
-  (advice-add 'ivy--minibuffer-setup :around #'ivy-posframe--minibuffer-setup)
-  (advice-add 'ivy--queue-exhibit :around #'ivy-posframe--add-prompt)
   (message "ivy-posframe is enabled, disabling it need to reboot emacs."))
 
 ;;;###autoload

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -519,22 +519,14 @@ selection, non-nil otherwise."
             ([remap ivy-dispatching-done] ivy-posframe-dispatching-done)
             ([remap ivy-avy] ivy-posframe-avy)
             ([remap swiper-avy] ivy-posframe-swiper-avy))
-  (let ((fncs ivy-posframe-display-function-list)
-        (advs ivy-posframe-advice-alist)
-        (configures ivy-posframe-configure-alist))
+  (let ((advices ivy-posframe-advice-alist))
     (if ivy-posframe-mode
         (eval
          `(progn
-            ,@(mapcan
-               (lambda (conf) (mapcar (lambda (elm) `(push ',elm ,(car conf))) (cdr conf))) configures)
-            ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ivy-posframe-cleanup) ivy-display-functions-props)) fncs)
-            ,@(mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) advs)))
+            ,@(mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) advices)))
       (eval
        `(progn
-          ,@(mapcan
-             (lambda (conf) (mapcar (lambda (elm) `(setq ,(car conf) (remove ',elm ,(car conf)))) (cdr conf))) configures)
-          ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ignore) ivy-display-functions-props)) fncs)
-          ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advs))))))
+          ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advices))))))
 
 ;;;###autoload
 (defun ivy-posframe-demo ()

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -121,6 +121,11 @@
   :group 'ivy
   :prefix "ivy-posframe")
 
+(defcustom ivy-posframe-display-functions-alist '((t . ivy-posframe-display))
+  "The ivy function, display function alist."
+  :group 'ivy-posframe
+  :type 'sexp)
+
 (defcustom ivy-posframe-style 'window-bottom-left
   "The style of ivy-posframe."
   :group 'ivy-posframe
@@ -460,15 +465,18 @@ selection, non-nil otherwise."
   :group 'ivy-posframe
   (let ((fncs ivy-posframe-display-function-list)
         (advs ivy-posframe-advice-alist)
-        (keys ivy-posframe-keybind-list))
+        (keys ivy-posframe-keybind-list)
+        (dfns ivy-posframe-display-functions-alist))
     (if ivy-posframe-mode
         (eval
          `(progn
+            ,@(mapcar (lambda (elm) `(push ',elm ivy-display-functions-alist)) dfns)
             ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ivy-posframe-cleanup) ivy-display-functions-props)) fncs)
             ,@(mapcar (lambda (elm) `(advice-add ',(car elm) :around #',(cdr elm))) advs)
             ,@(mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) ',(nth 2 elm))) keys)))
       (eval
        `(progn
+          ,@(mapcar (lambda (elm) `(setq ivy-display-functions-alist (delete ',elm ivy-display-functions-alist))) dfns)
           ,@(mapcar (lambda (elm) `(push '(,elm :cleanup ignore) ivy-display-functions-props)) fncs)
           ,@(mapcar (lambda (elm) `(advice-remove ',(car elm) #',(cdr elm))) advs)
           ,@(mapcar (lambda (elm) `(define-key ,(nth 0 elm) ,(nth 1 elm) nil)) keys))))))

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -434,15 +434,6 @@ selection, non-nil otherwise."
 
 ;;; variables
 
-(defvar ivy-posframe-display-functions
-  '(ivy-posframe-display
-    ivy-posframe-display-at-window-center
-    ivy-posframe-display-at-frame-center
-    ivy-posframe-display-at-window-bottom-left
-    ivy-posframe-display-at-frame-bottom-left
-    ivy-posframe-display-at-frame-bottom-window-center
-    ivy-posframe-display-at-point))
-
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup . ivy-posframe--minibuffer-setup)
     (ivy--queue-exhibit    . ivy-posframe--add-prompt)))
@@ -460,7 +451,11 @@ selection, non-nil otherwise."
   :global t
   :lighter " ivy-pf"
   :group 'ivy-posframe
-  (let ((fncs ivy-posframe-display-functions)
+  (let ((fncs (append (mapcar
+                       (lambda (elm) (intern (format "ivy-posframe-display-at-%s" (car elm))))
+                       ivy-posframe-display-functions-alist)
+                      '(ivy-posframe-display
+                        ivy-posframe-display-at-frame-bottom-window-center)))
         (advs ivy-posframe-advice-alist)
         (keys ivy-posframe-keybind-list))
     (if ivy-posframe-mode


### PR DESCRIPTION
Yesterday I made [another package](https://github.com/conao3/ddskk-posframe.el) related to posframe. The package uses minor mode and can be safely turned on and off.

I used that experience to redefine ivy-posframe as a minor mode using the same mechanism.
I changed a lot of code, so it would be helpful if you could check if it works in your environment.

As noted in the README, this variable is used for configuration.
```
(setq ivy-posframe-configure-alist
      '((ivy-display-functions-alist . ((swiper          . nil)
                                        (complete-symbol . ivy-posframe-display-at-point)
                                        (counsel-M-x     . ivy-posframe-display-at-window-bottom-left)
                                        (t               . ivy-posframe-display)))))
```


And if you have changed the variable for ivy, delete that line.
```
diff --git a/.dotfiles/.emacs.d/init.el b/.dotfiles/.emacs.d/init.el
index ee400d0..7ab77bf 100644
--- a/.dotfiles/.emacs.d/init.el
+++ b/.dotfiles/.emacs.d/init.el
@@ -855,9 +855,9 @@
         :doc "Using posframe to show Ivy"
         :when (version<= "26.1" emacs-version)
         :when window-system
         :ensure t
-        :custom ((ivy-height              40)
-                 (ivy-display-function    . #'ivy-posframe-display-at-frame-center)
-                 (ivy-posframe-parameters . '((left-fringe . 10))))
+        :custom ((ivy-posframe-parameters . '((left-fringe . 10))))
```

Then turn on `ivy-posframe-mode`, test it, and turn off it.