### PR TITLE
fix minor mode option

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -513,6 +513,7 @@ selection, non-nil otherwise."
   "Display ivy via posframe."
   :init-value nil
   :global t
+  :require 'ivy-posframe
   :lighter ivy-posframe-lighter
   :group 'ivy-posframe
   :keymap '(([remap ivy-avy]              . ivy-posframe-avy)


### PR DESCRIPTION
I enable minormode via `(customize-set-variables '(ivy-posframe-mode t))`, but ivy-posframe-mode doesn't work.
Since `company-posframe-mode` work with `customize-set-variables`, import options from company-posframe.
https://github.com/tumashu/company-posframe/blob/74091d132dea4b6ccd98c1ce7cec1b76b0ab8ad3/company-posframe.el#L152-L155

Maybe, I think `:require` option missing.