### PR TITLE
Fix First line disappears with the specific condition. #47

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -481,7 +481,8 @@ selection, non-nil otherwise."
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
           (goto-char (point-min))
-          (delete-region (point) (save-excursion (line-move 1 'noerror) (point)))
+          (kill-line 1)
+          (setq kill-ring (cdr kill-ring))
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -481,8 +481,8 @@ selection, non-nil otherwise."
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
           (goto-char (point-min))
-          (kill-line 1)
-          (setq kill-ring (cdr kill-ring))
+          (delete-region (point) (save-excursion (move-end-of-line 1) (point)))
+          (delete-char 1)
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 


### PR DESCRIPTION
It looks like the issue was occurred due to the difference between `(kill-line 1)` and `(delete-region (point) (save-excursion (line-move 1 'noerror) (point)))`
I restored `(kill-line 1)` and added `(setq kill-ring (cdr kill-ring))` to prevent `(kill-line 1)` copied the prompt text.

I've discussed with @conao3 about this approach on the previous pull request. However I think this has no harm since  `(kill-line 1)` and `(setq kill-ring (cdr kill-ring))` would be always executed in a row. `(setq kill-ring (cdr kill-ring))` will always remove only the last copied text from the kill-ring, which is copied by `(kill-line 1)`.