### PR TITLE
Fix for `Error in post-command-hook ...`

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -481,8 +481,8 @@ selection, non-nil otherwise."
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
           (goto-char (point-min))
-          (delete-region (point) (save-excursion (move-end-of-line 1) (point)))
-          (delete-char 1)
+          (delete-region (point)
+                         (save-excursion (line-move 1 'noerror) (beginning-of-line) (point)))
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 


### PR DESCRIPTION
I thought my fix was identical to the suggestion from @conao3 but it was not. 
You can see an error when there is no more candidates on the list. 
You can simply reproduce by `C-x b` and type aaaaaa.
I just applied the suggestion from @conao3 and found the issue has gone.
Thanks.