### PR TITLE
simplify get beginning position of next line

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -491,8 +491,7 @@ selection, non-nil otherwise."
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
           (goto-char (point-min))
-          (delete-region (point)
-                         (save-excursion (line-move 1 'noerror) (beginning-of-line) (point)))
+          (delete-region (point) (line-beginning-position 2))
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 


### PR DESCRIPTION
I found `line-beginning-position`, and
`(save-excursion (line-move 1 'noerror) (beginning-of-line) (point))` equals
`(line-beginning-position 2)`.

The new form is simpler than now form.

```
DEFUN ("line-beginning-position",
       Fline_beginning_position, Sline_beginning_position, 0, 1, 0,
       doc: /* Return the character position of the first character on the current line.
With optional argument N, scan forward N - 1 lines first.
If the scan reaches the end of the buffer, return that position.

This function ignores text display directionality; it returns the
position of the first character in logical order, i.e. the smallest
character position on the line.

This function constrains the returned position to the current field
unless that position would be on a different line than the original,
unconstrained result.  If N is nil or 1, and a front-sticky field
starts at point, the scan stops as soon as it starts.  To ignore field
boundaries, bind `inhibit-field-text-motion' to t.

This function does not move point.  */)
```