### PR TITLE
Make tab-width 2 in ivy-posframe-buffer

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -490,6 +490,7 @@ selection, non-nil otherwise."
             (prompt (buffer-string)))
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
+          (setq-local tab-width 2)
           (goto-char (point-min))
           (delete-region (point) (line-beginning-position 2))
           (insert prompt "  \n")

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -265,7 +265,9 @@ This variable is useful for `ivy-posframe-read-action' .")
              :internal-border-color (face-attribute 'ivy-posframe-border :background nil t)
              :override-parameters ivy-posframe-parameters
              (funcall ivy-posframe-size-function)))
-    (ivy-posframe--add-prompt 'ignore)))
+    (ivy-posframe--add-prompt 'ignore)
+    (with-current-buffer ivy-posframe-buffer
+      (setq-local tab-width 2))))
 
 (defun ivy-posframe-get-size ()
   "The default functon used by `ivy-posframe-size-function'."
@@ -490,7 +492,6 @@ selection, non-nil otherwise."
             (prompt (buffer-string)))
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
-          (setq-local tab-width 2)
           (goto-char (point-min))
           (delete-region (point) (line-beginning-position 2))
           (insert prompt "  \n")


### PR DESCRIPTION
CC: @asok

I found `all-the-icons-ivy` is broken in `ivy-posframe`.
That package expecting tab-width is 2, `ivy-posframe` use gloval `tab-width`.

Make `tab-width` 2 in only `ivy-posframe-buffer` to make that package work fine.

## SS
### bad (current)
![Capture 2019-06-13 2 41 57](https://user-images.githubusercontent.com/4703128/59373701-2b695180-8d85-11e9-89c0-79b3339fdf9c.png)

### good
![Capture 2019-06-13 2 42 19](https://user-images.githubusercontent.com/4703128/59373723-345a2300-8d85-11e9-9b34-dc52f7590123.png)

### All-the-icons-ivy SS
![](https://raw.githubusercontent.com/asok/all-the-icons-ivy/master/screenshot_0.png)