### PR TITLE
Check (display-graphic-p) dynamically in advices

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -467,6 +467,20 @@ selection, non-nil otherwise."
 
 ;;; Advice
 
+(defun ivy-posframe--posframe-p-advice (advice-fn &rest args)
+  "Advice function of ADVICE-FN, used to bypass the advice from
+`ivy-posframe-advice-alist' if the posframe cannot be displayed.
+
+ADVICE-FN should be a value from `ivy-posframe-advice-alist', but
+the function only errors if ARGS is empty. There should at least be
+the advised function there (a key from `ivy-posframe-advice-alist')."
+  (unless (< 0 (length args))
+    (error "This function should advise an advice, so args should be at least a key from ivy-posframe-advice-alist"))
+  (if (display-graphic-p)
+      (apply advice-fn args)
+    (apply (car args) (cdr args)))
+  )
+
 (defun ivy-posframe--minibuffer-setup (fn &rest args)
   "Advice function of FN, `ivy--minibuffer-setup' with ARGS."
   (let ((ivy-fixed-height-minibuffer nil))
@@ -532,10 +546,14 @@ selection, non-nil otherwise."
   (let ((advices ivy-posframe-advice-alist))
     (if ivy-posframe-mode
         (mapcar (lambda (elm)
-                  (advice-add (car elm) :around (cdr elm)))
+                  (progn
+                    (advice-add (cdr elm) :around 'ivy-posframe--posframe-p-advice)
+                    (advice-add (car elm) :around (cdr elm))))
                 advices)
       (mapcar (lambda (elm)
-                (advice-remove (car elm) (cdr elm)))
+                (progn
+                  (advice-remove (cdr elm) 'ivy-posframe--posframe-p-advice)
+                  (advice-remove (car elm) (cdr elm))))
               advices))))
 
 ;;;###autoload


### PR DESCRIPTION
This added check allows to run ivy-posframe in tty and gui emacs during the same session/with the same server.

I think it's not the cleanest way to do it, but I tested it locally (on MacOS) and that works for me at least (aka, same emacs server, I get posframes in gui emacs and classic minibuffer in tty).

Maybe advising the `ivy-posframe-advice-alist` is the way to go cleaner, I just wanted to propose a change to start with