### PR TITLE
Fix ivy-posframe--posframe-p-advice function

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -478,8 +478,7 @@ the advised function there (a key from `ivy-posframe-advice-alist')."
     (error "This function should advise an advice, so args should be at least a key from ivy-posframe-advice-alist"))
   (if (display-graphic-p)
       (apply advice-fn args)
-    (apply (car args) (cdr args)))
-  )
+    (apply (car args) (cdr args))))
 
 (defun ivy-posframe--minibuffer-setup (fn &rest args)
   "Advice function of FN, `ivy--minibuffer-setup' with ARGS."

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -469,13 +469,7 @@ selection, non-nil otherwise."
 
 (defun ivy-posframe--posframe-p-advice (advice-fn &rest args)
   "Advice function of ADVICE-FN, used to bypass the advice from
-`ivy-posframe-advice-alist' if the posframe cannot be displayed.
-
-ADVICE-FN should be a value from `ivy-posframe-advice-alist', but
-the function only errors if ARGS is empty. There should at least be
-the advised function there (a key from `ivy-posframe-advice-alist')."
-  (unless (< 0 (length args))
-    (error "This function should advise an advice, so args should be at least a key from ivy-posframe-advice-alist"))
+`ivy-posframe-advice-alist' if the posframe cannot be displayed."
   (if (display-graphic-p)
       (apply advice-fn args)
     (apply (car args) (cdr args))))


### PR DESCRIPTION
As PR #53 has merged, This PR code has some modifications in terms of coding style.

Also, in my experience, I have never encountered a situation where I give advice to an advice function. This can interfere with later code reading.

I'm still wondering if we really need advice on those advice function, but if we need it, I'd rather write a conditional branch for every advice function instead of the current tricky way.