### PR TITLE
Create defun advice

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -481,6 +481,23 @@ the advised function there (a key from `ivy-posframe-advice-alist')."
     (apply (car args) (cdr args)))
   )
 
+(defmacro ivy-posframe--defun-advice (name arglist &optional docstring &rest body)
+  "Define NAME as a `ivy-posframe' advice function.  see `defun'.
+The definition is (lambda ARGLIST [DOCSTRING] BODY...).
+See also the function `interactive'.
+DECL is a declaration, optional, of the form (declare DECLS...) where
+DECLS is a list of elements of the form (PROP . VALUES).  These are
+interpreted according to `defun-declarations-alist'.
+The return value is undefined.
+
+\(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
+  (declare (doc-string 3) (indent 2))
+  `(defun ,name ,arglist
+     ,(when (stringp docstring) docstring)
+     (when (display-graphic-p)
+       ,(unless (stringp docstring) docstring)
+       ,@body)))
+
 (defun ivy-posframe--minibuffer-setup (fn &rest args)
   "Advice function of FN, `ivy--minibuffer-setup' with ARGS."
   (let ((ivy-fixed-height-minibuffer nil))

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -467,20 +467,6 @@ selection, non-nil otherwise."
 
 ;;; Advice
 
-(defun ivy-posframe--posframe-p-advice (advice-fn &rest args)
-  "Advice function of ADVICE-FN, used to bypass the advice from
-`ivy-posframe-advice-alist' if the posframe cannot be displayed.
-
-ADVICE-FN should be a value from `ivy-posframe-advice-alist', but
-the function only errors if ARGS is empty. There should at least be
-the advised function there (a key from `ivy-posframe-advice-alist')."
-  (unless (< 0 (length args))
-    (error "This function should advise an advice, so args should be at least a key from ivy-posframe-advice-alist"))
-  (if (display-graphic-p)
-      (apply advice-fn args)
-    (apply (car args) (cdr args)))
-  )
-
 (defmacro ivy-posframe--defun-advice (name arglist &optional docstring &rest body)
   "Define NAME as a `ivy-posframe' advice function.  see `defun'.
 The definition is (lambda ARGLIST [DOCSTRING] BODY...).

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -498,7 +498,7 @@ The return value is undefined.
        ,(unless (stringp docstring) docstring)
        ,@body)))
 
-(defun ivy-posframe--minibuffer-setup (fn &rest args)
+(ivy-posframe--defun-advice ivy-posframe--minibuffer-setup (fn &rest args)
   "Advice function of FN, `ivy--minibuffer-setup' with ARGS."
   (let ((ivy-fixed-height-minibuffer nil))
     (apply fn args))
@@ -512,7 +512,7 @@ The return value is undefined.
                      `(:background ,bg-color :foreground ,bg-color)))
       (setq-local cursor-type nil))))
 
-(defun ivy-posframe--add-prompt (fn &rest args)
+(ivy-posframe--defun-advice ivy-posframe--add-prompt (fn &rest args)
   "Add the ivy prompt to the posframe.  Advice FN with ARGS."
   (apply fn args)
   (unless ivy-posframe--ignore-prompt
@@ -526,7 +526,7 @@ The return value is undefined.
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 
-(defun ivy-posframe--display-function-prop (fn &rest args)
+(ivy-posframe--defun-advice ivy-posframe--display-function-prop (fn &rest args)
   "Around advice of FN with ARGS."
   (let ((ivy-display-functions-props
          (append ivy-display-functions-props
@@ -536,13 +536,13 @@ The return value is undefined.
                   (mapcar #'cdr ivy-posframe-display-functions-alist)))))
     (apply fn args)))
 
-(defun ivy-posframe--height (fn &rest args)
+(ivy-posframe--defun-advice ivy-posframe--height (fn &rest args)
   "Around advide of FN with ARGS."
   (let ((ivy-height-alist
          (append ivy-posframe-height-alist ivy-height-alist)))
     (apply fn args)))
 
-(defun ivy-posframe--read (fn &rest args)
+(ivy-posframe--defun-advice ivy-posframe--read (fn &rest args)
   "Around advice of FN with AGS."
   (let ((ivy-display-functions-alist
          (append ivy-posframe-display-functions-alist ivy-display-functions-alist)))
@@ -564,12 +564,10 @@ The return value is undefined.
     (if ivy-posframe-mode
         (mapcar (lambda (elm)
                   (progn
-                    (advice-add (cdr elm) :around 'ivy-posframe--posframe-p-advice)
                     (advice-add (car elm) :around (cdr elm))))
                 advices)
       (mapcar (lambda (elm)
                 (progn
-                  (advice-remove (cdr elm) 'ivy-posframe--posframe-p-advice)
                   (advice-remove (car elm) (cdr elm))))
               advices))))
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -549,12 +549,10 @@ The return value is undefined.
   (let ((advices ivy-posframe-advice-alist))
     (if ivy-posframe-mode
         (mapcar (lambda (elm)
-                  (progn
-                    (advice-add (car elm) :around (cdr elm))))
+                  (advice-add (car elm) :around (cdr elm)))
                 advices)
       (mapcar (lambda (elm)
-                (progn
-                  (advice-remove (car elm) (cdr elm))))
+                (advice-remove (car elm) (cdr elm)))
               advices))))
 
 ;;;###autoload

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -478,11 +478,18 @@ The return value is undefined.
 
 \(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
   (declare (doc-string 3) (indent 2))
-  `(defun ,name ,arglist
-     ,(when (stringp docstring) docstring)
-     (when (display-graphic-p)
-       ,(unless (stringp docstring) docstring)
-       ,@body)))
+  (let ((decls (cond
+                ((eq (car-safe docstring) 'declare)
+                 (prog1 (cdr docstring) (setq docstring nil)))
+                ((and (stringp docstring)
+                      (eq (car-safe (car body)) 'declare))
+                 (prog1 (cdr (car body)) (setq body (cdr body)))))))
+    `(defun ,name ,arglist
+       ,(when (stringp docstring) docstring)
+       (declare ,@decls)
+       (when (display-graphic-p)
+         ,(unless (stringp docstring) docstring)
+         ,@body))))
 
 (ivy-posframe--defun-advice ivy-posframe--minibuffer-setup (fn &rest args)
   "Advice function of FN, `ivy--minibuffer-setup' with ARGS."


### PR DESCRIPTION
Related to the #55.
I implement another `defun` macro to define advice function and use it.

This change makes code simply and produces the same result.