### PR TITLE
fix warnings; use mapc instead of mapcar

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -555,10 +555,10 @@ The return value is undefined.
             ([remap ivy-dispatching-done] . ivy-posframe-dispatching-done))
   (let ((advices ivy-posframe-advice-alist))
     (if ivy-posframe-mode
-        (mapcar (lambda (elm)
+        (mapc (lambda (elm)
                   (advice-add (car elm) :around (cdr elm)))
                 advices)
-      (mapcar (lambda (elm)
+      (mapc (lambda (elm)
                 (advice-remove (car elm) (cdr elm)))
               advices))))
 

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -553,14 +553,13 @@ The return value is undefined.
             ([remap swiper-avy]           . ivy-posframe-swiper-avy)
             ([remap ivy-read-action]      . ivy-posframe-read-action)
             ([remap ivy-dispatching-done] . ivy-posframe-dispatching-done))
-  (let ((advices ivy-posframe-advice-alist))
-    (if ivy-posframe-mode
-        (mapc (lambda (elm)
-                  (advice-add (car elm) :around (cdr elm)))
-                advices)
+  (if ivy-posframe-mode
       (mapc (lambda (elm)
-                (advice-remove (car elm) (cdr elm)))
-              advices))))
+              (advice-add (car elm) :around (cdr elm)))
+            ivy-posframe-advice-alist)
+    (mapc (lambda (elm)
+            (advice-remove (car elm) (cdr elm)))
+          ivy-posframe-advice-alist)))
 
 ;;;###autoload
 (defun ivy-posframe-enable ()


### PR DESCRIPTION
Our package received below byte-compile warnings so fix it.

```
In ivy-posframe-mode:
ivy-posframe.el:562:8:Warning: ‘mapcar’ called for effect; use ‘mapc’ or
    ‘dolist’ instead
ivy-posframe.el:564:15:Warning: ‘mapcar’ called for effect; use ‘mapc’ or
    ‘dolist’ instead
```