### PR TITLE
Fix for prompt line duplicated issue in another way. #71

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -270,8 +270,7 @@ This variable is useful for `ivy-posframe-read-action' .")
              :internal-border-width ivy-posframe-border-width
              :internal-border-color (face-attribute 'ivy-posframe-border :background nil t)
              :override-parameters ivy-posframe-parameters
-             (funcall ivy-posframe-size-function)))
-    (ivy-posframe--add-prompt 'ignore)))
+             (funcall ivy-posframe-size-function)))))
 
 (defun ivy-posframe-get-size ()
   "The default functon used by `ivy-posframe-size-function'."
@@ -507,9 +506,7 @@ selection, non-nil otherwise."
         (remove-text-properties 0 (length prompt) '(read-only nil) prompt)
         (with-current-buffer ivy-posframe-buffer
           (goto-char (point-min))
-          (if (string-match-p "\n" prompt)
-              (delete-region (point) (line-beginning-position 3))
-            (delete-region (point) (line-beginning-position 2)))
+          (delete-region (point) (line-beginning-position 2))
           (insert prompt "  \n")
           (add-text-properties point (1+ point) '(face ivy-posframe-cursor)))))))
 


### PR DESCRIPTION
@tumashu  This is another fix for the issue #71 

I found the function `ivy-posframe--add-prompt`  is currently called twice so I removed the code calling the function from the end of `ivy-posframe--display`. And I restored `ivy-posframe--add-prompt`. And now it seems working fine for every cases.

However I wonder if it is okay to remove `(ivy-posframe--add-prompt 'ignore)` at the end of `ivy-posframe--display`. I haven't yet found the case where this change cause a problem but would appreciate for further review.

Thank you.
