### PR TITLE
Remove prompt replication in different approach. #71

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -270,7 +270,8 @@ This variable is useful for `ivy-posframe-read-action' .")
              :internal-border-width ivy-posframe-border-width
              :internal-border-color (face-attribute 'ivy-posframe-border :background nil t)
              :override-parameters ivy-posframe-parameters
-             (funcall ivy-posframe-size-function)))))
+             (funcall ivy-posframe-size-function))
+     (ivy-posframe--add-prompt 'ignore))))
 
 (defun ivy-posframe-get-size ()
   "The default functon used by `ivy-posframe-size-function'."
@@ -467,7 +468,6 @@ selection, non-nil otherwise."
 
 (defvar ivy-posframe-advice-alist
   '((ivy--minibuffer-setup      . ivy-posframe--minibuffer-setup)
-    (ivy--queue-exhibit         . ivy-posframe--add-prompt)
     (ivy--display-function-prop . ivy-posframe--display-function-prop)
     (ivy--height                . ivy-posframe--height)
     (ivy-read                   . ivy-posframe--read)))


### PR DESCRIPTION
@tumashu I found prompt is overwritten when the content of ivy-posframe keep updating  in specific cases such as `counsel-rg`. So this is another approach that restores calling `(ivy-posframe--add-prompt 'ignore)` from `ivy-posframe--display` so that prompt will be also re-written when the content of the ivy-posframe is updated.
And I removed `ivy-posframe--add-prompt` from `ivy-posframe-advice-alist` to prevent the duplication of the prompt line.

This time I've tested most of existing ivy/counsel functions and it looks okay.
I would appreciate for further review. I really hope this approach wouldn't break the design of `ivy-posframe`.
Thank you.