### PR TITLE
fix issues with posframe install on windows

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -567,7 +567,7 @@ selection, non-nil otherwise."
 (provide 'ivy-posframe)
 
 ;; Local Variables:
-;; coding: utf-8-unix
+;; coding: utf-8
 ;; End:
 
 ;;; ivy-posframe.el ends here


### PR DESCRIPTION
Hi I've been getting cryptic errors when trying to install `ivy-posframe` on a Windows 10 machine:

```
There was an unexpected error:
  (error ivy-posframe.el:0:0: error: error: (Local variables entry is missing the suffix))
  FIND: Invalid switch
```

**Note:** I use [doom-emacs](https://github.com/hlissner/doom-emacs) which recently switched to using `straight.el` for package installation, but regardless seems it probably doesn't need to be `utf-8-unix` specifically?

I've now confirmed changing the line in the commit fixes the problem, assuming no other issues would you mind accepting the pull request?