### PR TITLE
Fix issue where ivy-posframe jumps around, and other issues

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -535,6 +535,27 @@ Otherwise, error."
 
 ;;; Advice
 
+(defun ivy-posframe--minibuffer-setup (fn &rest args)
+  "Advice function of FN, `ivy--minibuffer-setup' with ARGS."
+  (if (not (display-graphic-p))
+      (apply fn args)
+    (let ((ivy-fixed-height-minibuffer nil))
+      (apply fn args))
+    (when (and ivy-posframe-hide-minibuffer
+               (posframe-workable-p)
+               ;; if display-function is not a ivy-posframe style display-function.
+               ;; do not hide minibuffer.
+               ;; The hypothesis is that all ivy-posframe style display functions
+               ;; have ivy-posframe as name prefix, need improve!
+               (string-match-p "ivy-posframe" (symbol-name ivy--display-function)))
+      (let ((ov (make-overlay (point-min) (point-max) nil nil t)))
+        (overlay-put ov 'window (selected-window))
+        (overlay-put ov 'ivy-posframe t)
+        (overlay-put ov 'face
+                     (let ((bg-color (face-background 'default nil)))
+                       `(:background ,bg-color :foreground ,bg-color)))
+        (setq-local cursor-type nil)))))
+
 (defun ivy-posframe--add-prompt (fn &rest args)
   "Add the ivy prompt to the posframe.  Advice FN with ARGS."
   (apply fn args)

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -239,24 +239,48 @@ This variable is useful for `ivy-posframe-read-action' .")
 (defvar emacs-basic-display)
 (defvar ivy--display-function)
 
+(defun ivy-posframe--convert-size-px (size full)
+  "Convert a SIZE to pixels where FULL is the maximum width/height.
+
+The returned pixel size `out' will always fit 0 <= `out' <= `full'.
+
+The SIZE can be one of `integer', `float', or `function'
+If SIZE is a `float', then it represents a fraction of FULL.
+If SIZE is an `integer', then it /is/ the size.
+If SIZE is a `function', then the result of calling it with no parameters
+is the size.
+Otherwise, error."
+  (max 0 (min (cl-typecase size
+                (integer size)
+                (float (truncate (* full size)))
+                (function (funcall size))
+                (t (error "Invalid SIZE type")))
+              full)))
+
 (defun ivy-posframe--display (str &optional poshandler)
   "Show STR in ivy's posframe with POSHANDLER."
-  (if (not (posframe-workable-p))
-      (ivy-display-function-fallback str)
-    (with-ivy-window
-      (apply #'posframe-show
-             ivy-posframe-buffer
-             :font ivy-posframe-font
-             :string str
-             :position (point)
-             :poshandler poshandler
-             :background-color (face-attribute 'ivy-posframe :background nil t)
-             :foreground-color (face-attribute 'ivy-posframe :foreground nil t)
-             :internal-border-width ivy-posframe-border-width
-             :internal-border-color (face-attribute 'ivy-posframe-border :background nil t)
-             :override-parameters ivy-posframe-parameters
-             (funcall ivy-posframe-size-function))
-      (ivy-posframe--add-prompt 'ignore))))
+  (let ((width (or (alist-get 'width ivy-posframe-parameters) 0.80))
+        (height (or (alist-get 'height ivy-posframe-parameters) 0.15)))
+    (if (posframe-workable-p)
+        (with-ivy-window
+          (apply #'posframe-show
+                 ivy-posframe-buffer
+                 :font ivy-posframe-font
+                 :string str
+                 :position (point)
+                 :poshandler poshandler
+                 :background-color (face-attribute 'ivy-posframe :background nil t)
+                 :foreground-color (face-attribute 'ivy-posframe :foreground nil t)
+                 :internal-border-width ivy-posframe-border-width
+                 :width (ivy-posframe--convert-size-px width (frame-width))
+                 :height (ivy-posframe--convert-size-px height (frame-height))
+                 :internal-border-color (face-attribute 'ivy-posframe-border :background nil t)
+                 :override-parameters ivy-posframe-parameters
+                 (funcall ivy-posframe-size-function))
+          (ivy-posframe--add-prompt 'ignore))
+      (ivy-display-function-fallback str))
+    (with-current-buffer ivy-posframe-buffer
+      (setq-local truncate-lines ivy-truncate-lines))))
 
 (defun ivy-posframe-get-size ()
   "The default functon used by `ivy-posframe-size-function'."

--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -543,11 +543,9 @@ Otherwise, error."
       (apply fn args))
     (when (and ivy-posframe-hide-minibuffer
                (posframe-workable-p)
-               ;; if display-function is not a ivy-posframe style display-function.
-               ;; do not hide minibuffer.
-               ;; The hypothesis is that all ivy-posframe style display functions
-               ;; have ivy-posframe as name prefix, need improve!
-               (string-match-p "ivy-posframe" (symbol-name ivy--display-function)))
+               ;; Assume that we only need the framebuffer if using ivy-display-function-fallback
+               (not (eq 'ivy-display-function-fallback
+                        ivy--display-function)))
       (let ((ov (make-overlay (point-min) (point-max) nil nil t)))
         (overlay-put ov 'window (selected-window))
         (overlay-put ov 'ivy-posframe t)


### PR DESCRIPTION
- Added `:width` and `:height` parameters to `posframe-show`, they default to 80% of `(frame-width)` and 15% of `(frame-height)`, but can otherwise be configured with `ivy-posframe-parameters`.
- Changed how `ivy-posframe--minibuffer-setup` checks if it is using posframe, instead of assuming that the function should start with `ivy-posframe`, we instead check whether `ivy--display-function` is set to `'ivy-display-function-callback` or not.
  - This fixes an issue in Doom Emacs, where it will always display the minibuffer
  - Swiper, and other windows that shouldn't be displayed as posframes still display the minibuffer.
- `truncate-lines` is set in the `ivy-posframe-buffer` according to `ivy-truncate-lines`, if this isn't done the text flows to the next line.