### PR TITLE
Set truncate-lines to ivy-truncate-lines

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -256,7 +256,9 @@ This variable is useful for `ivy-posframe-read-action' .")
              :internal-border-color (face-attribute 'ivy-posframe-border :background nil t)
              :override-parameters ivy-posframe-parameters
              (funcall ivy-posframe-size-function))
-      (ivy-posframe--add-prompt 'ignore))))
+      (ivy-posframe--add-prompt 'ignore)))
+  (with-current-buffer ivy-posframe-buffer
+    (setq-local truncate-lines ivy-truncate-lines)))
 
 (defun ivy-posframe-get-size ()
   "The default functon used by `ivy-posframe-size-function'."


### PR DESCRIPTION
This keeps the text from flowing over in the posframe.