### PR TITLE
Fix to properly exit the action list #103

### DIFF
--- a/ivy-posframe.el
+++ b/ivy-posframe.el
@@ -361,15 +361,16 @@ This variable is useful for `ivy-posframe-read-action' .")
                                     (string-prefix-p key (car x)))
                                   (cdr actions)))
                 (not (string= key (car (nth action-idx (cdr actions))))))
-      (setq key (concat key (string
-                             (read-key
-                              (if (functionp display-function)
-                                  (let ((ivy-posframe--ignore-prompt t))
-                                    (funcall display-function hint)
-                                    "Please type a key: ")
-                                hint))))))
+      (setq key (concat key (key-description
+                             (vector
+                              (read-key
+                               (if (functionp display-function)
+                                   (let ((ivy-posframe--ignore-prompt t))
+                                     (funcall display-function hint)
+                                     "Please type a key: ")
+                                 hint)))))))
     (ivy-shrink-after-dispatching)
-    (cond ((member key '("ESC" "C-g"))
+    (cond ((member key '("ESC" "C-g" "M-o"))
            nil)
           ((null action-idx)
            (message "%s is not bound" key)


### PR DESCRIPTION
This is to solve issue #103 but not whole issues but the second part of my summary.
This is almost identical to the pull request I made on `ivy`(swiper) repository. (https://github.com/abo-abo/swiper/pull/2757)
The pull request on `ivy` isn't accepted yet but I believe this will safely solve a problem from issue #103.

Details of the pull requests are as below:
1. Fix that pressing `ESC` is showing "^[ is not bound" issue.
2. Fix that pressing `C-g` is showing "^[ is not bound" issue.
3. Add support `M-o` key bind to properly exit the action list.
4. Make unbound key message more intuitive. (ex. "^A is not bound" -> "C-a is not bound")

Thanks.